### PR TITLE
Simplify down to just "dotnet pack"

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -114,46 +114,9 @@ jobs:
     #- name: Environment for Publish/Pack
     #  run: env
 
-    #- name: dotnet publish
-    #  run: >
-    #    dotnet publish ${{ env.SOLUTION_FILE }}
-    #    --configuration ${{ env.RELEASE_CONFIG }}
-    #    /p:Version="${{ env.RELEASE_VERSION }}"
-    #    /p:InformationalVersion="${{ env.RELEASE_VERSION }}"
-
-    # The "dotnet pack" command doesn't seem to have good wildcard support?
-
-    - name: dotnet pack (Lussatite.FeatureManagement)
+    - name: dotnet pack
       run: >
         dotnet pack
-        src/Lussatite.FeatureManagement/Lussatite.FeatureManagement.csproj
-        --configuration ${{ env.RELEASE_CONFIG }}
-        /p:Version="${{ env.RELEASE_VERSION }}"
-        --include-symbols
-        --output artifacts/
-
-    - name: dotnet pack (Lussatite.FeatureManagement.LazyCache)
-      run: >
-        dotnet pack
-        src/Lussatite.FeatureManagement.LazyCache/Lussatite.FeatureManagement.LazyCache.csproj
-        --configuration ${{ env.RELEASE_CONFIG }}
-        /p:Version="${{ env.RELEASE_VERSION }}"
-        --include-symbols
-        --output artifacts/
-
-    - name: dotnet pack (Lussatite.FeatureManagement.SessionManagers.Core)
-      run: >
-        dotnet pack
-        src/Lussatite.FeatureManagement.SessionManagers.Core/Lussatite.FeatureManagement.SessionManagers.Core.csproj
-        --configuration ${{ env.RELEASE_CONFIG }}
-        /p:Version="${{ env.RELEASE_VERSION }}"
-        --include-symbols
-        --output artifacts/
-
-    - name: dotnet pack (Lussatite.FeatureManagement.SessionManagers.Framework)
-      run: >
-        dotnet pack
-        src/Lussatite.FeatureManagement.SessionManagers.Framework/Lussatite.FeatureManagement.SessionManagers.Framework.csproj
         --configuration ${{ env.RELEASE_CONFIG }}
         /p:Version="${{ env.RELEASE_VERSION }}"
         --include-symbols


### PR DESCRIPTION
Now that all csproj files are converted to the new style, it should
be possible to only need a single "dotnet pack" instead of listing
each project separately.