### PR TITLE
Add ClaimsPrincipalSessionManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,15 +45,17 @@ Target: .NET Standard 2.0
 
 Target: .NET Core 3.1 (also compatible with .NET 5+)
 
-- `ConfigurationValueSessionManager`: A read-only ISessionManager implementation that uses `IConfiguration` to obtain its values.
-- `SqlSessionManager`: A read-only ISessionManager implementation that uses a user-provided `DbCommand` to obtain its values.
+- `ClaimsPrincipalSessionManager`: A read-only `ISessionManager` implementation using "feature_flag" claims on a `ClaimsPrincipal`.
+- `ConfigurationValueSessionManager`: A read-only `ISessionManager` implementation that uses `IConfiguration`.
+- `SqlSessionManager`: A read-only `ISessionManager` implementation that uses a user-provided `DbCommand`.
 
 ### Lussatite.FeatureManagement.SessionManagers.Framework:
 
 Target: .NET Framework 4.8
 
-- `ConfigurationValueSessionManager`: A read-only ISessionManager implementation that uses the .NET Framework static class `ConfigurationManager` to obtain its values.
-- `SqlSessionManager`: A read-only ISessionManager implementation that uses a user-provided `DbCommand` to obtain its values.
+- `ClaimsPrincipalSessionManager`: A read-only `ISessionManager` implementation using "feature_flag" claims on a `ClaimsPrincipal`.
+- `ConfigurationValueSessionManager`: A read-only `ISessionManager` implementation that uses the .NET Framework static class `ConfigurationManager`.
+- `SqlSessionManager`: A read-only `ISessionManager` implementation that uses a user-provided `DbCommand`.
 
 ## Build Status
 

--- a/src/Lussatite.FeatureManagement.SessionManagers.Core/ClaimsPrincipal/ClaimsPrincipalSessionManager.cs
+++ b/src/Lussatite.FeatureManagement.SessionManagers.Core/ClaimsPrincipal/ClaimsPrincipalSessionManager.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Linq;
+using Microsoft.FeatureManagement;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+// ReSharper disable once CheckNamespace
+namespace Lussatite.FeatureManagement.SessionManagers
+{
+    /// <summary>
+    /// <para>A read-only <see cref="ISessionManager"/> implementation that examines claims
+    /// of type <see cref="FeatureFlagClaimType"/> to determine the specified feature flag
+    /// name's value.</para>
+    /// <para>This type should be registered/constructed on a per-request basis
+    /// since it takes dependency on the current user (<see cref="ClaimsPrincipal"/>).</para>
+    /// </summary>
+    public class ClaimsPrincipalSessionManager : ISessionManager
+    {
+        /// <summary>The claim type that will be examined when determining whether the
+        /// current <see cref="ClaimsPrincipal"/> has the claim for a particular
+        /// feature name. The expectation is that the value of this claim will
+        /// be something that can be parsed as the feature name.  Feature names
+        /// that are prefixed with an exclamation point indicate "false".</summary>
+        public const string FeatureFlagClaimType = "feature_flag";
+
+        // https://docs.microsoft.com/en-us/dotnet/api/system.security.claims.claimtypes
+
+        private readonly ClaimsPrincipal _claimsPrincipal;
+
+        /// <summary>Construct the session manager associated with the specified
+        /// <see cref="ClaimsPrincipal"/> object, such as the user.</summary>
+        /// <param name="claimsPrincipal"><see cref="ClaimsPrincipal"/></param>
+        public ClaimsPrincipalSessionManager(
+            ClaimsPrincipal claimsPrincipal
+            )
+        {
+            _claimsPrincipal = claimsPrincipal
+                ?? throw new ArgumentNullException(nameof(claimsPrincipal));
+        }
+
+        /// <summary>This session manager does not write values back. It is a read-only provider.</summary>
+        public Task SetAsync(string featureName, bool enabled)
+        {
+            return Task.CompletedTask;
+        }
+
+        public async Task<bool?> GetAsync(string featureName)
+        {
+            var featureClaim = await Task.FromResult(_claimsPrincipal.Claims
+                .FirstOrDefault(x =>
+                    x.Type == FeatureFlagClaimType
+                    && (
+                        x.Value.Equals(featureName, StringComparison.OrdinalIgnoreCase)
+                        || x.Value.Equals($"!{featureName}", StringComparison.OrdinalIgnoreCase)
+                        )
+                    ));
+
+            if (featureClaim is null) return null;
+            return featureClaim.Value.Substring(0, 1) != "!";
+        }
+    }
+}

--- a/src/Lussatite.FeatureManagement.SessionManagers.Core/README.md
+++ b/src/Lussatite.FeatureManagement.SessionManagers.Core/README.md
@@ -6,9 +6,13 @@ Various read-only [ISessionManager](https://docs.microsoft.com/en-us/dotnet/api/
 
 While these `ISessionManager` implementations are written for `Lussatite.FeatureManagement`, they are compatible with the Microsoft `ISessionManager` interface and could be used with the Microsoft `FeatureManager` implementation.
 
+### ClaimsPrincipalSessionManager
+
+A read-only `ISessionManager` implementation that examines `ClaimsPrincipal` claims of type "feature_flag" to obtain the feature value.  The value of the claim is either the feature name to indicate true, or the feature name prefixed with an exclamation point ("!") to indicate false.
+
 ### ConfigurationValueSessionManager
 
-A read-only ISessionManager implementation that uses `IConfiguration` to obtain its values.
+A read-only `ISessionManager` implementation that uses `IConfiguration` to obtain its values.
 
 ### SqlSessionManager
 

--- a/src/Lussatite.FeatureManagement.SessionManagers.Framework/ClaimsPrincipal/ClaimsPrincipalSessionManager.cs
+++ b/src/Lussatite.FeatureManagement.SessionManagers.Framework/ClaimsPrincipal/ClaimsPrincipalSessionManager.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Linq;
+using Microsoft.FeatureManagement;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+// ReSharper disable once CheckNamespace
+namespace Lussatite.FeatureManagement.SessionManagers.Framework
+{
+    //NOTE: This is a copy of the one from Lussatite.FeatureManagement.SessionManagers.Core
+    // For reasons, the SessionManagers are grouped into a .NET Framework package and a .NET Core / .NET 5+ package.
+
+    /// <summary>
+    /// <para>A read-only <see cref="ISessionManager"/> implementation that examines claims
+    /// of type <see cref="FeatureFlagClaimType"/> to determine the specified feature flag
+    /// name's value.</para>
+    /// <para>This type should be registered/constructed on a per-request basis
+    /// since it takes dependency on the current user (<see cref="ClaimsPrincipal"/>).</para>
+    /// </summary>
+    public class ClaimsPrincipalSessionManager : ISessionManager
+    {
+        /// <summary>The claim type that will be examined when determining whether the
+        /// current <see cref="ClaimsPrincipal"/> has the claim for a particular
+        /// feature name. The expectation is that the value of this claim will
+        /// be something that can be parsed as the feature name.  Feature names
+        /// that are prefixed with an exclamation point indicate "false".</summary>
+        public const string FeatureFlagClaimType = "feature_flag";
+
+        // https://docs.microsoft.com/en-us/dotnet/api/system.security.claims.claimtypes
+
+        private readonly ClaimsPrincipal _claimsPrincipal;
+
+        /// <summary>Construct the session manager associated with the specified
+        /// <see cref="ClaimsPrincipal"/> object, such as the user.</summary>
+        /// <param name="claimsPrincipal"><see cref="ClaimsPrincipal"/></param>
+        public ClaimsPrincipalSessionManager(
+            ClaimsPrincipal claimsPrincipal
+            )
+        {
+            _claimsPrincipal = claimsPrincipal
+                ?? throw new ArgumentNullException(nameof(claimsPrincipal));
+        }
+
+        /// <summary>This session manager does not write values back. It is a read-only provider.</summary>
+        public Task SetAsync(string featureName, bool enabled)
+        {
+            return Task.CompletedTask;
+        }
+
+        public async Task<bool?> GetAsync(string featureName)
+        {
+            var featureClaim = await Task.FromResult(_claimsPrincipal.Claims
+                .FirstOrDefault(x =>
+                    x.Type == FeatureFlagClaimType
+                    && (
+                        x.Value.Equals(featureName, StringComparison.OrdinalIgnoreCase)
+                        || x.Value.Equals($"!{featureName}", StringComparison.OrdinalIgnoreCase)
+                        )
+                    ));
+
+            if (featureClaim is null) return null;
+            return featureClaim.Value.Substring(0, 1) != "!";
+        }
+    }
+}

--- a/src/Lussatite.FeatureManagement.SessionManagers.Framework/README.md
+++ b/src/Lussatite.FeatureManagement.SessionManagers.Framework/README.md
@@ -6,9 +6,13 @@ Various read-only [ISessionManager](https://docs.microsoft.com/en-us/dotnet/api/
 
 While these `ISessionManager` implementations are written for `Lussatite.FeatureManagement`, they are compatible with the Microsoft `ISessionManager` interface and could be used with the Microsoft `FeatureManager` implementation.
 
+### ClaimsPrincipalSessionManager
+
+A read-only `ISessionManager` implementation that examines `ClaimsPrincipal` claims of type "feature_flag" to obtain the feature value.  The value of the claim is either the feature name to indicate true, or the feature name prefixed with an exclamation point ("!") to indicate false.
+
 ### ConfigurationValueSessionManager
 
-A read-only ISessionManager implementation that uses the .NET Framework static class `ConfigurationManager` to obtain its values.
+A read-only `ISessionManager` implementation that uses the .NET Framework static class `ConfigurationManager` to obtain its values.
 
 ### SqlSessionManager
 

--- a/tests/Lussatite.FeatureManagement.SessionManagers.Core.Tests/ClaimsPrincipals/ClaimsPrincipalSessionManagerTests.cs
+++ b/tests/Lussatite.FeatureManagement.SessionManagers.Core.Tests/ClaimsPrincipals/ClaimsPrincipalSessionManagerTests.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Lussatite.FeatureManagement.SessionManagers;
+using Xunit;
+
+namespace Lussatite.FeatureManagement.AspNetCore.Tests.ClaimsPrincipals
+{
+    public class ClaimsPrincipalSessionManagerTests
+    {
+        private ClaimsPrincipal CreateClaimsPrincipal(IEnumerable<string> featureFlagValues)
+        {
+            var claims = featureFlagValues
+                .Select(x => new Claim(ClaimsPrincipalSessionManager.FeatureFlagClaimType, x))
+                .ToList();
+            return CreateClaimsPrincipal(claims);
+        }
+
+        private ClaimsPrincipal CreateClaimsPrincipal(List<Claim> claims)
+        {
+            var identity = new ClaimsIdentity(claims: claims);
+            var principal = new ClaimsPrincipal(identity);
+            return principal;
+        }
+
+        [Fact]
+        public async Task GetAsync_returns_true_for_featureName_with_no_prefix()
+        {
+            const string featureName = "abc456-true";
+            var principal = CreateClaimsPrincipal(new[]
+            {
+                "someOtherFeatureTrue",
+                featureName,
+                "!someOtherFeatureFalse",
+            });
+            var sut = new ClaimsPrincipalSessionManager(principal);
+            var result = await sut.GetAsync(featureName);
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task GetAsync_returns_false_for_featureName_with_exclamation_prefix()
+        {
+            const string featureName = "Xyz123-false";
+            var principal = CreateClaimsPrincipal(new[]
+            {
+                "ThisOtherUnrelatedFeature",
+                $"!{featureName}",
+            });
+            var sut = new ClaimsPrincipalSessionManager(principal);
+            var result = await sut.GetAsync(featureName);
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task GetAsync_returns_null_for_featureName_not_set()
+        {
+            const string featureName = "QRS175-null";
+            var principal = CreateClaimsPrincipal(new[]
+            {
+                $"FeatureNot{featureName}",
+                "TotallyNotAFeature",
+                $"{featureName}NotFeatureEither",
+            });
+            var sut = new ClaimsPrincipalSessionManager(principal);
+            var result = await sut.GetAsync(featureName);
+            Assert.Null(result);
+        }
+    }
+}

--- a/tests/Lussatite.FeatureManagement.SessionManagers.Framework.Tests/ClaimsPrincipals/ClaimsPrincipalSessionManagerTests.cs
+++ b/tests/Lussatite.FeatureManagement.SessionManagers.Framework.Tests/ClaimsPrincipals/ClaimsPrincipalSessionManagerTests.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Lussatite.FeatureManagement.SessionManagers.Framework.Tests.ClaimsPrincipals
+{
+    public class ClaimsPrincipalSessionManagerTests
+    {
+        private ClaimsPrincipal CreateClaimsPrincipal(IEnumerable<string> featureFlagValues)
+        {
+            var claims = featureFlagValues
+                .Select(x => new Claim(ClaimsPrincipalSessionManager.FeatureFlagClaimType, x))
+                .ToList();
+            return CreateClaimsPrincipal(claims);
+        }
+
+        private ClaimsPrincipal CreateClaimsPrincipal(List<Claim> claims)
+        {
+            var identity = new ClaimsIdentity(claims: claims);
+            var principal = new ClaimsPrincipal(identity);
+            return principal;
+        }
+
+        [Fact]
+        public async Task GetAsync_returns_true_for_featureName_with_no_prefix()
+        {
+            const string featureName = "abc456-true";
+            var principal = CreateClaimsPrincipal(new[]
+            {
+                "someOtherFeatureTrue",
+                featureName,
+                "!someOtherFeatureFalse",
+            });
+            var sut = new ClaimsPrincipalSessionManager(principal);
+            var result = await sut.GetAsync(featureName);
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task GetAsync_returns_false_for_featureName_with_exclamation_prefix()
+        {
+            const string featureName = "Xyz123-false";
+            var principal = CreateClaimsPrincipal(new[]
+            {
+                "ThisOtherUnrelatedFeature",
+                $"!{featureName}",
+            });
+            var sut = new ClaimsPrincipalSessionManager(principal);
+            var result = await sut.GetAsync(featureName);
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task GetAsync_returns_null_for_featureName_not_set()
+        {
+            const string featureName = "QRS175-null";
+            var principal = CreateClaimsPrincipal(new[]
+            {
+                $"FeatureNot{featureName}",
+                "TotallyNotAFeature",
+                $"{featureName}NotFeatureEither",
+            });
+            var sut = new ClaimsPrincipalSessionManager(principal);
+            var result = await sut.GetAsync(featureName);
+            Assert.Null(result);
+        }
+    }
+}


### PR DESCRIPTION
A read-only ISessionManager that looks at the set of claims on a
ClaimsPrincipal to determine whether the feature flag value is
null/false/true.