### PR TITLE
Add a CachedSqlSessionManager ISessionManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Target: .NET Core 3.1 (also compatible with .NET 5+)
 - `ClaimsPrincipalSessionManager`: A read-only `ISessionManager` implementation using "feature_flag" claims on a `ClaimsPrincipal`.
 - `ConfigurationValueSessionManager`: A read-only `ISessionManager` implementation that uses `IConfiguration`.
 - `SqlSessionManager`: A read-only `ISessionManager` implementation that uses a user-provided `DbCommand`.
+- `CachedSqlSessionManager`: A read-only `ISessionManager` implementation which adds caching to database calls.
 
 ### Lussatite.FeatureManagement.SessionManagers.Framework:
 
@@ -56,6 +57,7 @@ Target: .NET Framework 4.8
 - `ClaimsPrincipalSessionManager`: A read-only `ISessionManager` implementation using "feature_flag" claims on a `ClaimsPrincipal`.
 - `ConfigurationValueSessionManager`: A read-only `ISessionManager` implementation that uses the .NET Framework static class `ConfigurationManager`.
 - `SqlSessionManager`: A read-only `ISessionManager` implementation that uses a user-provided `DbCommand`.
+- `CachedSqlSessionManager`: A read-only `ISessionManager` implementation which adds caching to database calls.
 
 ## Build Status
 

--- a/src/Lussatite.FeatureManagement.SessionManagers.Core/Lussatite.FeatureManagement.SessionManagers.Core.csproj
+++ b/src/Lussatite.FeatureManagement.SessionManagers.Core/Lussatite.FeatureManagement.SessionManagers.Core.csproj
@@ -23,6 +23,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="LazyCache" Version="2.4.0" />
     <PackageReference Include="Microsoft.FeatureManagement" Version="2.5.1" />
   </ItemGroup>
 

--- a/src/Lussatite.FeatureManagement.SessionManagers.Core/README.md
+++ b/src/Lussatite.FeatureManagement.SessionManagers.Core/README.md
@@ -18,6 +18,10 @@ A read-only `ISessionManager` implementation that uses `IConfiguration` to obtai
 
 A read-only `ISessionManager` implementation that uses a user-provided `DbCommand` to obtain its values.
 
+### CachedSqlSessionManager
+
+A cached read-only `ISessionManager` implementation that uses a user-provided `DbCommand` to obtain its values.  The results for a particular feature flag name will be cached for a period.  The default cache duration is 30 seconds.
+
 ## Target
 
 - .NET Core 3.1

--- a/src/Lussatite.FeatureManagement.SessionManagers.Core/Sql/CachedSqlSessionManager.cs
+++ b/src/Lussatite.FeatureManagement.SessionManagers.Core/Sql/CachedSqlSessionManager.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Data.Common;
+using System.Threading.Tasks;
+using LazyCache;
+
+// ReSharper disable once CheckNamespace
+namespace Lussatite.FeatureManagement.SessionManagers
+{
+    /// <summary>A caching version of <see cref="SqlSessionManager"/> which reduces the
+    /// number of calls to the underlying database.</summary>
+    public class CachedSqlSessionManager : SqlSessionManager
+    {
+        private readonly IAppCache _cache;
+        private readonly CachedSqlSessionManagerSettings _cachedSettings;
+
+        public CachedSqlSessionManager(
+            Func<string, DbCommand> getValueCommandFactory,
+            CachedSqlSessionManagerSettings settings = null,
+            IAppCache cache = null
+            ) : base(getValueCommandFactory, settings)
+        {
+            _cachedSettings = settings ?? new CachedSqlSessionManagerSettings();
+            if (_cachedSettings.CacheTime.Seconds <= 0)
+                throw new ArgumentOutOfRangeException(nameof(_cachedSettings.CacheTime));
+            _cache = cache ?? new CachingService();
+        }
+
+        public override async Task<bool?> GetAsync(string featureName)
+        {
+            if (string.IsNullOrWhiteSpace(featureName)) return false;
+            var cacheKey = $"Lussatite.FeatureManagement:{nameof(CachedSqlSessionManager)}:{featureName}";
+            var absoluteExpiration = DateTimeOffset.UtcNow.Add(_cachedSettings.CacheTime);
+
+            return await _cache.GetOrAddAsync(
+                expires: absoluteExpiration,
+                key: cacheKey,
+                addItemFactory: async () => await base.GetAsync(featureName).ConfigureAwait(false)
+                );
+        }
+    }
+}

--- a/src/Lussatite.FeatureManagement.SessionManagers.Core/Sql/CachedSqlSessionManagerSettings.cs
+++ b/src/Lussatite.FeatureManagement.SessionManagers.Core/Sql/CachedSqlSessionManagerSettings.cs
@@ -1,0 +1,13 @@
+
+using System;
+
+// ReSharper disable once CheckNamespace
+namespace Lussatite.FeatureManagement.SessionManagers
+{
+    public class CachedSqlSessionManagerSettings : SqlSessionManagerSettings
+    {
+        /// <summary>How long a cache entry will be valid until it is forced to
+        /// refresh from the database.  Defaults to 30 seconds.</summary>
+        public TimeSpan CacheTime { get; set; } = TimeSpan.FromSeconds(30);
+    }
+}

--- a/src/Lussatite.FeatureManagement.SessionManagers.Core/Sql/SqlSessionManager.cs
+++ b/src/Lussatite.FeatureManagement.SessionManagers.Core/Sql/SqlSessionManager.cs
@@ -2,7 +2,6 @@ using Microsoft.FeatureManagement;
 using System;
 using System.Data;
 using System.Data.Common;
-using System.Data.SqlClient;
 using System.Threading.Tasks;
 
 // ReSharper disable once CheckNamespace
@@ -31,7 +30,7 @@ namespace Lussatite.FeatureManagement.SessionManagers
             _settings = settings ?? new SqlSessionManagerSettings();
         }
 
-        public async Task<bool?> GetAsync(string featureName)
+        public virtual async Task<bool?> GetAsync(string featureName)
         {
             var dbCommand = _dbCommandFactory(featureName);
             if (dbCommand is null)

--- a/src/Lussatite.FeatureManagement.SessionManagers.Framework/Lussatite.FeatureManagement.SessionManagers.Framework.csproj
+++ b/src/Lussatite.FeatureManagement.SessionManagers.Framework/Lussatite.FeatureManagement.SessionManagers.Framework.csproj
@@ -30,4 +30,8 @@
     <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="LazyCache" Version="2.4.0" />
+  </ItemGroup>
+
 </Project>

--- a/src/Lussatite.FeatureManagement.SessionManagers.Framework/README.md
+++ b/src/Lussatite.FeatureManagement.SessionManagers.Framework/README.md
@@ -18,6 +18,10 @@ A read-only `ISessionManager` implementation that uses the .NET Framework static
 
 A read-only `ISessionManager` implementation that uses a user-provided `DbCommand` to obtain its values.
 
+### CachedSqlSessionManager
+
+A cached read-only `ISessionManager` implementation that uses a user-provided `DbCommand` to obtain its values.  The results for a particular feature flag name will be cached for a period.  The default cache duration is 30 seconds.
+
 ## Target
 
 - .NET Framework 4.8

--- a/src/Lussatite.FeatureManagement.SessionManagers.Framework/Sql/CachedSqlSessionManager.cs
+++ b/src/Lussatite.FeatureManagement.SessionManagers.Framework/Sql/CachedSqlSessionManager.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Data.Common;
+using System.Threading.Tasks;
+using LazyCache;
+
+// ReSharper disable once CheckNamespace
+namespace Lussatite.FeatureManagement.SessionManagers.Framework
+{
+    /// <summary>A caching version of <see cref="SqlSessionManager"/> which reduces the
+    /// number of calls to the underlying database.</summary>
+    public class CachedSqlSessionManager : SqlSessionManager
+    {
+        //NOTE: This is a copy of the one from Lussatite.FeatureManagement.SessionManagers.Core
+        //Because DbCommand is not .NET Standard 2.0, we are splitting along Framework/Core lines.
+
+        private readonly IAppCache _cache;
+        private readonly CachedSqlSessionManagerSettings _cachedSettings;
+
+        public CachedSqlSessionManager(
+            Func<string, DbCommand> getValueCommandFactory,
+            CachedSqlSessionManagerSettings settings = null,
+            IAppCache cache = null
+            ) : base(getValueCommandFactory, settings)
+        {
+            _cachedSettings = settings ?? new CachedSqlSessionManagerSettings();
+            if (_cachedSettings.CacheTime.Seconds <= 0)
+                throw new ArgumentOutOfRangeException(nameof(_cachedSettings.CacheTime));
+            _cache = cache ?? new CachingService();
+        }
+
+        public override async Task<bool?> GetAsync(string featureName)
+        {
+            if (string.IsNullOrWhiteSpace(featureName)) return false;
+            var cacheKey = $"Lussatite.FeatureManagement:{nameof(CachedSqlSessionManager)}:{featureName}";
+            var absoluteExpiration = DateTimeOffset.UtcNow.Add(_cachedSettings.CacheTime);
+
+            return await _cache.GetOrAddAsync(
+                expires: absoluteExpiration,
+                key: cacheKey,
+                addItemFactory: async () => await base.GetAsync(featureName).ConfigureAwait(false)
+                );
+        }
+    }
+}

--- a/src/Lussatite.FeatureManagement.SessionManagers.Framework/Sql/CachedSqlSessionManagerSettings.cs
+++ b/src/Lussatite.FeatureManagement.SessionManagers.Framework/Sql/CachedSqlSessionManagerSettings.cs
@@ -1,0 +1,15 @@
+using System;
+
+// ReSharper disable once CheckNamespace
+namespace Lussatite.FeatureManagement.SessionManagers.Framework
+{
+    public class CachedSqlSessionManagerSettings : SqlSessionManagerSettings
+    {
+        //NOTE: This is a copy of the one from Lussatite.FeatureManagement.SessionManagers.Core
+        //Because DbCommand is not .NET Standard 2.0, we are splitting along Framework/Core lines.
+
+        /// <summary>How long a cache entry will be valid until it is forced to
+        /// refresh from the database.  Defaults to 30 seconds.</summary>
+        public TimeSpan CacheTime { get; set; } = TimeSpan.FromSeconds(30);
+    }
+}

--- a/src/Lussatite.FeatureManagement.SessionManagers.Framework/Sql/SqlSessionManager.cs
+++ b/src/Lussatite.FeatureManagement.SessionManagers.Framework/Sql/SqlSessionManager.cs
@@ -2,7 +2,6 @@ using Microsoft.FeatureManagement;
 using System;
 using System.Data;
 using System.Data.Common;
-using System.Data.SqlClient;
 using System.Threading.Tasks;
 
 // ReSharper disable once CheckNamespace
@@ -34,7 +33,7 @@ namespace Lussatite.FeatureManagement.SessionManagers.Framework
             _settings = settings ?? new SqlSessionManagerSettings();
         }
 
-        public async Task<bool?> GetAsync(string featureName)
+        public virtual async Task<bool?> GetAsync(string featureName)
         {
             var dbCommand = _dbCommandFactory(featureName);
             if (dbCommand is null)

--- a/tests/Lussatite.FeatureManagement.SessionManagers.Core.Tests/Sql/CachedSqlSessionManagerTests.cs
+++ b/tests/Lussatite.FeatureManagement.SessionManagers.Core.Tests/Sql/CachedSqlSessionManagerTests.cs
@@ -1,0 +1,80 @@
+using System.Data.SQLite;
+using System.Threading.Tasks;
+using Lussatite.FeatureManagement.AspNetCore.Tests.Testing.SQLite;
+using Lussatite.FeatureManagement.SessionManagers;
+using Xunit;
+
+namespace Lussatite.FeatureManagement.AspNetCore.Tests.Sql
+{
+    [Collection(nameof(SQLiteDatabaseCollection))]
+    public class CachedSqlSessionManagerTests
+    {
+        private readonly SQLiteDatabaseFixture _dbFixture;
+
+        public CachedSqlSessionManagerTests(SQLiteDatabaseFixture dbFixture)
+        {
+            _dbFixture = dbFixture;
+        }
+
+        private CachedSqlSessionManager CreateSut()
+        {
+            var baseSettings = _dbFixture.SqlSessionManagerSettings;
+            var settings = new CachedSqlSessionManagerSettings
+            {
+                FeatureNameColumn = baseSettings.FeatureNameColumn,
+                FeatureValueColumn = baseSettings.FeatureValueColumn,
+            };
+
+            return new CachedSqlSessionManager(
+                settings: settings,
+                getValueCommandFactory: s => _dbFixture.CreateGetValueCommand(s)
+                );
+        }
+
+        [Fact]
+        public async Task Return_null_for_nonexistent_key()
+        {
+            var sut = CreateSut();
+            var result = await sut.GetAsync("someRandomFeatureNonExistentName");
+            Assert.Null(result);
+        }
+
+        [Theory]
+        [InlineData(null, "A125a_FeatureSetToNull", null)]
+        [InlineData(false, "A125b_FeatureSetToFalse", 0)]
+        [InlineData(true, "A125c_FeatureSetToTrue", 1)]
+        public async Task Return_expected_for_inserted_key_value(
+            bool? expected,
+            string featureName,
+            int? insertValue
+            )
+        {
+            using (var conn = new SQLiteConnection(_dbFixture.GetConnectionString()))
+            {
+                conn.Open();
+
+                var updateCommand = conn.CreateCommand();
+                updateCommand.CommandText =
+                $@"
+                    INSERT INTO {SQLiteDatabaseFixture.TableName}
+                    ({SQLiteDatabaseFixture.NameColumn}, {SQLiteDatabaseFixture.ValueColumn})
+                    VALUES (@featureName, @featureValue)
+                    ON CONFLICT({SQLiteDatabaseFixture.NameColumn})
+                    DO UPDATE SET {SQLiteDatabaseFixture.ValueColumn}=@featureValue
+                ";
+                updateCommand.Parameters.Add(new SQLiteParameter("featureName", featureName));
+                updateCommand.Parameters.Add(new SQLiteParameter("featureValue", insertValue));
+                updateCommand.ExecuteNonQuery();
+
+                conn.Close();
+            }
+
+            var featureTableValues = await _dbFixture.GetAllData();
+            Assert.NotEmpty(featureTableValues);
+
+            var sut = CreateSut();
+            var result = await sut.GetAsync(featureName);
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/tests/Lussatite.FeatureManagement.SessionManagers.Framework.Tests/Sql/CachedSqlSessionManagerTests.cs
+++ b/tests/Lussatite.FeatureManagement.SessionManagers.Framework.Tests/Sql/CachedSqlSessionManagerTests.cs
@@ -1,0 +1,79 @@
+using Lussatite.FeatureManagement.SessionManagers.Framework.Tests.Testing.SQLite;
+using System.Data.SQLite;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Lussatite.FeatureManagement.SessionManagers.Framework.Tests.Sql
+{
+    [Collection(nameof(SQLiteDatabaseCollection))]
+    public class CachedSqlSessionManagerTests
+    {
+        private readonly SQLiteDatabaseFixture _dbFixture;
+
+        public CachedSqlSessionManagerTests(SQLiteDatabaseFixture dbFixture)
+        {
+            _dbFixture = dbFixture;
+        }
+
+        private CachedSqlSessionManager CreateSut()
+        {
+            var baseSettings = _dbFixture.SqlSessionManagerSettings;
+            var settings = new CachedSqlSessionManagerSettings
+            {
+                FeatureNameColumn = baseSettings.FeatureNameColumn,
+                FeatureValueColumn = baseSettings.FeatureValueColumn,
+            };
+
+            return new CachedSqlSessionManager(
+                settings: settings,
+                getValueCommandFactory: s => _dbFixture.CreateGetValueCommand(s)
+                );
+        }
+
+        [Fact]
+        public async Task Return_null_for_nonexistent_key()
+        {
+            var sut = CreateSut();
+            var result = await sut.GetAsync("someRandomFeatureNonExistentName");
+            Assert.Null(result);
+        }
+
+        [Theory]
+        [InlineData(null, "A125a_FeatureSetToNull", null)]
+        [InlineData(false, "A125b_FeatureSetToFalse", 0)]
+        [InlineData(true, "A125c_FeatureSetToTrue", 1)]
+        public async Task Return_expected_for_inserted_key_value(
+            bool? expected,
+            string featureName,
+            int? insertValue
+            )
+        {
+            using (var conn = new SQLiteConnection(_dbFixture.GetConnectionString()))
+            {
+                conn.Open();
+
+                var updateCommand = conn.CreateCommand();
+                updateCommand.CommandText =
+                $@"
+                    INSERT INTO {SQLiteDatabaseFixture.TableName}
+                    ({SQLiteDatabaseFixture.NameColumn}, {SQLiteDatabaseFixture.ValueColumn})
+                    VALUES (@featureName, @featureValue)
+                    ON CONFLICT({SQLiteDatabaseFixture.NameColumn})
+                    DO UPDATE SET {SQLiteDatabaseFixture.ValueColumn}=@featureValue
+                ";
+                updateCommand.Parameters.Add(new SQLiteParameter("featureName", featureName));
+                updateCommand.Parameters.Add(new SQLiteParameter("featureValue", insertValue));
+                updateCommand.ExecuteNonQuery();
+
+                conn.Close();
+            }
+
+            var featureTableValues = await _dbFixture.GetAllData();
+            Assert.NotEmpty(featureTableValues);
+
+            var sut = CreateSut();
+            var result = await sut.GetAsync(featureName);
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/tests/Lussatite.FeatureManagement.SessionManagers.Framework.Tests/Testing/SQLite/SQLiteDatabaseFixture.cs
+++ b/tests/Lussatite.FeatureManagement.SessionManagers.Framework.Tests/Testing/SQLite/SQLiteDatabaseFixture.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Data;
 using System.Data.Common;
 using System.Data.SQLite;
 using System.Threading.Tasks;


### PR DESCRIPTION
Create a class that inherits from `SqlSessionManager` and adds a cache layer.  The default TTL for any values is 30 seconds.