### PR TITLE
Add ILussatiteSessionManager and SQL write-back

### DIFF
--- a/src/Lussatite.FeatureManagement.SessionManagers/Lussatite.FeatureManagement.SessionManagers.csproj
+++ b/src/Lussatite.FeatureManagement.SessionManagers/Lussatite.FeatureManagement.SessionManagers.csproj
@@ -31,4 +31,8 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Lussatite.FeatureManagement\Lussatite.FeatureManagement.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/Lussatite.FeatureManagement.SessionManagers/Sql/CachedSqlSessionManager.cs
+++ b/src/Lussatite.FeatureManagement.SessionManagers/Sql/CachedSqlSessionManager.cs
@@ -13,11 +13,30 @@ namespace Lussatite.FeatureManagement.SessionManagers
         private readonly IAppCache _cache;
         private readonly CachedSqlSessionManagerSettings _cachedSettings;
 
+        /// <summary>Construct the <see cref="CachedSqlSessionManager"/> instance.</summary>
+        /// <param name="getValueCommandFactory">A <see cref="DbCommand"/> query which must
+        /// filter down to the single row matching the feature name string.</param>
+        /// <param name="setValueCommandFactory">An optional <see cref="DbCommand"/> query which
+        /// must support being an INSERT/UPDATE (UPSERT) of the bool value into the database table.
+        /// Note that you rarely want to use this in practice, unless your SQL table is already
+        /// per-user or per-session.</param>
+        /// <param name="setNullableValueCommandFactory">An optional <see cref="DbCommand"/> query which
+        /// must support being an INSERT/UPDATE (UPSERT) of the nullable bool value into the database table.
+        /// </param>
+        /// <param name="settings"><see cref="CachedSqlSessionManagerSettings"/></param>
+        /// <param name="cache">Optional application-wide <see cref="IAppCache"/> instance.</param>
         public CachedSqlSessionManager(
             Func<string, DbCommand> getValueCommandFactory,
+            Func<string, bool, DbCommand> setValueCommandFactory = null,
+            Func<string, bool?, DbCommand> setNullableValueCommandFactory = null,
             CachedSqlSessionManagerSettings settings = null,
             IAppCache cache = null
-            ) : base(getValueCommandFactory, settings)
+            ) : base(
+            settings: settings,
+            getValueCommandFactory: getValueCommandFactory,
+            setValueCommandFactory: setValueCommandFactory,
+            setNullableValueCommandFactory: setNullableValueCommandFactory
+            )
         {
             _cachedSettings = settings ?? new CachedSqlSessionManagerSettings();
             if (_cachedSettings.CacheTime.Seconds <= 0)
@@ -25,17 +44,55 @@ namespace Lussatite.FeatureManagement.SessionManagers
             _cache = cache ?? new CachingService();
         }
 
+        /// <inheritdoc cref="SqlSessionManager.GetAsync"/>
         public override async Task<bool?> GetAsync(string featureName)
         {
             if (string.IsNullOrWhiteSpace(featureName)) return false;
-            var cacheKey = $"Lussatite.FeatureManagement:{nameof(CachedSqlSessionManager)}:{featureName}";
-            var absoluteExpiration = DateTimeOffset.UtcNow.Add(_cachedSettings.CacheTime);
+            var cacheKey = CalculateCacheKey(featureName);
+            var absoluteExpiration = CalculateAbsoluteExpiration();
 
             return await _cache.GetOrAddAsync(
                 expires: absoluteExpiration,
                 key: cacheKey,
                 addItemFactory: async () => await base.GetAsync(featureName).ConfigureAwait(false)
                 );
+        }
+
+        /// <inheritdoc cref="SqlSessionManager.SetAsync"/>
+        public override async Task SetAsync(string featureName, bool enabled)
+        {
+            await base.SetAsync(featureName, enabled).ConfigureAwait(false);
+
+            var cacheKey = CalculateCacheKey(featureName);
+            var absoluteExpiration = CalculateAbsoluteExpiration();
+            _cache.Add(cacheKey, enabled, absoluteExpiration);
+        }
+
+        /// <inheritdoc cref="SqlSessionManager.SetNullableAsync"/>
+        public override async Task SetNullableAsync(string featureName, bool? enabled)
+        {
+            await base.SetNullableAsync(featureName, enabled).ConfigureAwait(false);
+
+            var cacheKey = CalculateCacheKey(featureName);
+            var absoluteExpiration = CalculateAbsoluteExpiration();
+            _cache.GetOrAdd(
+                expires: absoluteExpiration,
+                key: cacheKey,
+                addItemFactory: () => enabled
+                );
+            // _cache.Add() does not currently support null values
+            // https://github.com/alastairtree/LazyCache/issues/155
+            // _cache.Add(cacheKey, enabled, absoluteExpiration);
+        }
+
+        private static string CalculateCacheKey(string featureName)
+        {
+            return $"Lussatite.FeatureManagement:{nameof(CachedSqlSessionManager)}:{featureName}";
+        }
+
+        private DateTimeOffset CalculateAbsoluteExpiration()
+        {
+            return DateTimeOffset.UtcNow.Add(_cachedSettings.CacheTime);
         }
     }
 }

--- a/src/Lussatite.FeatureManagement/ILussatiteSessionManager.cs
+++ b/src/Lussatite.FeatureManagement/ILussatiteSessionManager.cs
@@ -1,0 +1,23 @@
+using System.Threading.Tasks;
+using Microsoft.FeatureManagement;
+
+namespace Lussatite.FeatureManagement
+{
+    public interface ILussatiteSessionManager : ISessionManager
+    {
+        /// <summary>
+        /// <para>Set the nullable state of a feature to be used for a session.</para>
+        /// <para>This differs from the base <see cref="ISessionManager.SetAsync"/> method in that
+        /// it takes a nullable boolean and is not called by the Microsoft <see cref="IFeatureManager"/>
+        /// or <see cref="IFeatureManagerSnapshot"/> implementations.  The Microsoft implementations
+        /// assume that you always want to write back the value at the end of the
+        /// <see cref="IFeatureManager.IsEnabledAsync"/> method after calculating the various
+        /// answers provided by <see cref="FeatureDefinition"/>.</para>
+        /// <para>In my experience, setting the value in the session manager should be done prior
+        /// to the call to <see cref="IFeatureManager.IsEnabledAsync"/>.</para>
+        /// </summary>
+        /// <param name="featureName">The name of the feature.</param>
+        /// <param name="enabled">The nullable state of the feature.</param>
+        Task SetNullableAsync(string featureName, bool? enabled);
+    }
+}

--- a/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Sql/CachedSqlSessionManagerTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Sql/CachedSqlSessionManagerTests.cs
@@ -2,7 +2,6 @@ using System.Data.SQLite;
 using System.Threading.Tasks;
 using Lussatite.FeatureManagement.Net48.Tests.Testing.SQLite;
 using Lussatite.FeatureManagement.SessionManagers;
-using Lussatite.FeatureManagement.SessionManagers.Framework;
 using Xunit;
 
 namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
@@ -28,7 +27,9 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
 
             return new CachedSqlSessionManager(
                 settings: settings,
-                getValueCommandFactory: s => _dbFixture.CreateGetValueCommand(s)
+                getValueCommandFactory: s => _dbFixture.CreateGetValueCommand(s),
+                setValueCommandFactory: (s, e) => _dbFixture.CreateSetValueCommand(s, e),
+                setNullableValueCommandFactory: (s, e) => _dbFixture.CreateSetNullableValueCommand(s, e)
                 );
         }
 
@@ -41,9 +42,9 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         }
 
         [Theory]
-        [InlineData(null, "A125a_FeatureSetToNull", null)]
-        [InlineData(false, "A125b_FeatureSetToFalse", 0)]
-        [InlineData(true, "A125c_FeatureSetToTrue", 1)]
+        [InlineData(null, "Net48_A125a_FeatureSetToNull", null)]
+        [InlineData(false, "Net48_A125b_FeatureSetToFalse", 0)]
+        [InlineData(true, "Net48_A125c_FeatureSetToTrue", 1)]
         public async Task Return_expected_for_inserted_key_value(
             bool? expected,
             string featureName,
@@ -74,6 +75,47 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
             Assert.NotEmpty(featureTableValues);
 
             var sut = CreateSut();
+            var result = await sut.GetAsync(featureName);
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData(null, "Net48_A349x_FeatureSetToNull", null)]
+        [InlineData(false, "Net48_A349y_FeatureSetToFalse", false)]
+        [InlineData(true, "Net48_A349z_FeatureSetToTrue", true)]
+        public async Task Return_expected_for_SetNullableValue(
+            bool? expected,
+            string featureName,
+            bool? enabled
+            )
+        {
+            var sut = CreateSut();
+            await sut.SetNullableAsync(featureName, enabled);
+
+            var featureTableValues = await _dbFixture.GetAllData();
+            Assert.NotEmpty(featureTableValues);
+
+            var result = await sut.GetAsync(featureName);
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData(null, "Net48_A359jx_FeatureSetToNull", null)]
+        [InlineData(false, "Net48_A359ky_FeatureSetToFalse", false)]
+        [InlineData(true, "Net48_A359lz_FeatureSetToTrue", true)]
+        public async Task Return_expected_for_SetValue(
+            bool? expected,
+            string featureName,
+            bool? enabled
+            )
+        {
+            var sut = CreateSut();
+            if (enabled.HasValue) await sut.SetAsync(featureName, enabled.Value);
+            else await sut.SetNullableAsync(featureName, null);
+
+            var featureTableValues = await _dbFixture.GetAllData();
+            Assert.NotEmpty(featureTableValues);
+
             var result = await sut.GetAsync(featureName);
             Assert.Equal(expected, result);
         }

--- a/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Sql/SqlSessionManagerTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Sql/SqlSessionManagerTests.cs
@@ -2,7 +2,6 @@ using System.Data.SQLite;
 using System.Threading.Tasks;
 using Lussatite.FeatureManagement.Net48.Tests.Testing.SQLite;
 using Lussatite.FeatureManagement.SessionManagers;
-using Lussatite.FeatureManagement.SessionManagers.Framework;
 using Xunit;
 
 namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
@@ -21,8 +20,10 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         {
             return new SqlSessionManager(
                 settings: _dbFixture.SqlSessionManagerSettings,
-                getValueCommandFactory: s => _dbFixture.CreateGetValueCommand(s)
-            );
+                getValueCommandFactory: s => _dbFixture.CreateGetValueCommand(s),
+                setValueCommandFactory: (s, e) => _dbFixture.CreateSetValueCommand(s, e),
+                setNullableValueCommandFactory: (s, e) => _dbFixture.CreateSetNullableValueCommand(s, e)
+                );
         }
 
         [Fact]
@@ -34,9 +35,9 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         }
 
         [Theory]
-        [InlineData(null, "A125a_FeatureSetToNull", null)]
-        [InlineData(false, "A125b_FeatureSetToFalse", 0)]
-        [InlineData(true, "A125c_FeatureSetToTrue", 1)]
+        [InlineData(null, "Net48_A125a_FeatureSetToNull", null)]
+        [InlineData(false, "Net48_A125b_FeatureSetToFalse", 0)]
+        [InlineData(true, "Net48_A125c_FeatureSetToTrue", 1)]
         public async Task Return_expected_for_inserted_key_value(
             bool? expected,
             string featureName,
@@ -67,6 +68,47 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
             Assert.NotEmpty(featureTableValues);
 
             var sut = CreateSut();
+            var result = await sut.GetAsync(featureName);
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData(null, "Net48_A129x_FeatureSetToNull", null)]
+        [InlineData(false, "Net48_A129y_FeatureSetToFalse", false)]
+        [InlineData(true, "Net48_A129z_FeatureSetToTrue", true)]
+        public async Task Return_expected_for_SetNullableValue(
+            bool? expected,
+            string featureName,
+            bool? enabled
+            )
+        {
+            var sut = CreateSut();
+            await sut.SetNullableAsync(featureName, enabled);
+
+            var featureTableValues = await _dbFixture.GetAllData();
+            Assert.NotEmpty(featureTableValues);
+
+            var result = await sut.GetAsync(featureName);
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData(null, "Net48_A139jx_FeatureSetToNull", null)]
+        [InlineData(false, "Net48_A139ky_FeatureSetToFalse", false)]
+        [InlineData(true, "Net48_A139lz_FeatureSetToTrue", true)]
+        public async Task Return_expected_for_SetValue(
+            bool? expected,
+            string featureName,
+            bool? enabled
+            )
+        {
+            var sut = CreateSut();
+            if (enabled.HasValue) await sut.SetAsync(featureName, enabled.Value);
+            else await sut.SetNullableAsync(featureName, null);
+
+            var featureTableValues = await _dbFixture.GetAllData();
+            Assert.NotEmpty(featureTableValues);
+
             var result = await sut.GetAsync(featureName);
             Assert.Equal(expected, result);
         }

--- a/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Sql/CachedSqlSessionManagerTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Sql/CachedSqlSessionManagerTests.cs
@@ -27,7 +27,9 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
 
             return new CachedSqlSessionManager(
                 settings: settings,
-                getValueCommandFactory: s => _dbFixture.CreateGetValueCommand(s)
+                getValueCommandFactory: s => _dbFixture.CreateGetValueCommand(s),
+                setValueCommandFactory: (s, e) => _dbFixture.CreateSetValueCommand(s, e),
+                setNullableValueCommandFactory: (s, e) => _dbFixture.CreateSetNullableValueCommand(s, e)
                 );
         }
 
@@ -39,10 +41,11 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
             Assert.Null(result);
         }
 
+
         [Theory]
-        [InlineData(null, "A125a_FeatureSetToNull", null)]
-        [InlineData(false, "A125b_FeatureSetToFalse", 0)]
-        [InlineData(true, "A125c_FeatureSetToTrue", 1)]
+        [InlineData(null, "Net6_A125a_FeatureSetToNull", null)]
+        [InlineData(false, "Net6_A125b_FeatureSetToFalse", 0)]
+        [InlineData(true, "Net6_A125c_FeatureSetToTrue", 1)]
         public async Task Return_expected_for_inserted_key_value(
             bool? expected,
             string featureName,
@@ -73,6 +76,47 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
             Assert.NotEmpty(featureTableValues);
 
             var sut = CreateSut();
+            var result = await sut.GetAsync(featureName);
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData(null, "Net6_A349x_FeatureSetToNull", null)]
+        [InlineData(false, "Net6_A349y_FeatureSetToFalse", false)]
+        [InlineData(true, "Net6_A349z_FeatureSetToTrue", true)]
+        public async Task Return_expected_for_SetNullableValue(
+            bool? expected,
+            string featureName,
+            bool? enabled
+            )
+        {
+            var sut = CreateSut();
+            await sut.SetNullableAsync(featureName, enabled);
+
+            var featureTableValues = await _dbFixture.GetAllData();
+            Assert.NotEmpty(featureTableValues);
+
+            var result = await sut.GetAsync(featureName);
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData(null, "Net6_A359jx_FeatureSetToNull", null)]
+        [InlineData(false, "Net6_A359ky_FeatureSetToFalse", false)]
+        [InlineData(true, "Net6_A359lz_FeatureSetToTrue", true)]
+        public async Task Return_expected_for_SetValue(
+            bool? expected,
+            string featureName,
+            bool? enabled
+            )
+        {
+            var sut = CreateSut();
+            if (enabled.HasValue) await sut.SetAsync(featureName, enabled.Value);
+            else await sut.SetNullableAsync(featureName, null);
+
+            var featureTableValues = await _dbFixture.GetAllData();
+            Assert.NotEmpty(featureTableValues);
+
             var result = await sut.GetAsync(featureName);
             Assert.Equal(expected, result);
         }

--- a/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Sql/SqlSessionManagerTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Sql/SqlSessionManagerTests.cs
@@ -20,8 +20,10 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
         {
             return new SqlSessionManager(
                 settings: _dbFixture.SqlSessionManagerSettings,
-                getValueCommandFactory: s => _dbFixture.CreateGetValueCommand(s)
-            );
+                getValueCommandFactory: s => _dbFixture.CreateGetValueCommand(s),
+                setValueCommandFactory: (s, e) => _dbFixture.CreateSetValueCommand(s, e),
+                setNullableValueCommandFactory: (s, e) => _dbFixture.CreateSetNullableValueCommand(s, e)
+                );
         }
 
         [Fact]
@@ -33,9 +35,9 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
         }
 
         [Theory]
-        [InlineData(null, "A125a_FeatureSetToNull", null)]
-        [InlineData(false, "A125b_FeatureSetToFalse", 0)]
-        [InlineData(true, "A125c_FeatureSetToTrue", 1)]
+        [InlineData(null, "Net6_A125a_FeatureSetToNull", null)]
+        [InlineData(false, "Net6_A125b_FeatureSetToFalse", 0)]
+        [InlineData(true, "Net6_A125c_FeatureSetToTrue", 1)]
         public async Task Return_expected_for_inserted_key_value(
             bool? expected,
             string featureName,
@@ -66,6 +68,47 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
             Assert.NotEmpty(featureTableValues);
 
             var sut = CreateSut();
+            var result = await sut.GetAsync(featureName);
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData(null, "Net6_A129x_FeatureSetToNull", null)]
+        [InlineData(false, "Net6_A129y_FeatureSetToFalse", false)]
+        [InlineData(true, "Net6_A129z_FeatureSetToTrue", true)]
+        public async Task Return_expected_for_SetNullableValue(
+            bool? expected,
+            string featureName,
+            bool? enabled
+            )
+        {
+            var sut = CreateSut();
+            await sut.SetNullableAsync(featureName, enabled);
+
+            var featureTableValues = await _dbFixture.GetAllData();
+            Assert.NotEmpty(featureTableValues);
+
+            var result = await sut.GetAsync(featureName);
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData(null, "Net6_A139jx_FeatureSetToNull", null)]
+        [InlineData(false, "Net6_A139ky_FeatureSetToFalse", false)]
+        [InlineData(true, "Net6_A139lz_FeatureSetToTrue", true)]
+        public async Task Return_expected_for_SetValue(
+            bool? expected,
+            string featureName,
+            bool? enabled
+            )
+        {
+            var sut = CreateSut();
+            if (enabled.HasValue) await sut.SetAsync(featureName, enabled.Value);
+            else await sut.SetNullableAsync(featureName, null);
+
+            var featureTableValues = await _dbFixture.GetAllData();
+            Assert.NotEmpty(featureTableValues);
+
             var result = await sut.GetAsync(featureName);
             Assert.Equal(expected, result);
         }

--- a/tests/Lussatite.FeatureManagement.Net6.Tests/Testing/SQLite/SQLiteDatabaseFixture.cs
+++ b/tests/Lussatite.FeatureManagement.Net6.Tests/Testing/SQLite/SQLiteDatabaseFixture.cs
@@ -62,6 +62,49 @@ namespace Lussatite.FeatureManagement.Net6.Tests.Testing.SQLite
             return queryCommand;
         }
 
+        public DbCommand CreateSetNullableValueCommand(string featureName, bool? enabled)
+        {
+            var conn = new SQLiteConnection(connectionString);
+            conn.Open();
+
+            int? featureValue = null;
+            if (enabled.HasValue) featureValue = enabled.Value ? 1 : 0;
+            var queryCommand = conn.CreateCommand();
+            queryCommand.CommandText =
+                $@"
+                    INSERT INTO {TableName}
+                    ({NameColumn}, {ValueColumn})
+                    VALUES (@featureName, @featureValue)
+                    ON CONFLICT({NameColumn})
+                    DO UPDATE SET {ValueColumn}=@featureValue
+                ";
+            queryCommand.Parameters.Add(new SQLiteParameter("featureName", featureName));
+            queryCommand.Parameters.Add(new SQLiteParameter("@featureValue", featureValue));
+
+            return queryCommand;
+        }
+
+        public DbCommand CreateSetValueCommand(string featureName, bool enabled)
+        {
+            var conn = new SQLiteConnection(connectionString);
+            conn.Open();
+
+            var featureValue = enabled ? 1 : 0;
+            var queryCommand = conn.CreateCommand();
+            queryCommand.CommandText =
+                $@"
+                    INSERT INTO {TableName}
+                    ({NameColumn}, {ValueColumn})
+                    VALUES (@featureName, @featureValue)
+                    ON CONFLICT({NameColumn})
+                    DO UPDATE SET {ValueColumn}=@featureValue
+                ";
+            queryCommand.Parameters.Add(new SQLiteParameter("featureName", featureName));
+            queryCommand.Parameters.Add(new SQLiteParameter("@featureValue", featureValue));
+
+            return queryCommand;
+        }
+
         /// <summary>Meant to be used as a debug step, this returns all of the data in the table.</summary>
         public async Task<List<object[]>> GetAllData()
         {

--- a/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/Sql/CachedSqlSessionManagerTests.cs
+++ b/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/Sql/CachedSqlSessionManagerTests.cs
@@ -27,7 +27,9 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
 
             return new CachedSqlSessionManager(
                 settings: settings,
-                getValueCommandFactory: s => _dbFixture.CreateGetValueCommand(s)
+                getValueCommandFactory: s => _dbFixture.CreateGetValueCommand(s),
+                setValueCommandFactory: (s, e) => _dbFixture.CreateSetValueCommand(s, e),
+                setNullableValueCommandFactory: (s, e) => _dbFixture.CreateSetNullableValueCommand(s, e)
                 );
         }
 
@@ -39,10 +41,11 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
             Assert.Null(result);
         }
 
+
         [Theory]
-        [InlineData(null, "A125a_FeatureSetToNull", null)]
-        [InlineData(false, "A125b_FeatureSetToFalse", 0)]
-        [InlineData(true, "A125c_FeatureSetToTrue", 1)]
+        [InlineData(null, "NetCore31_A125a_FeatureSetToNull", null)]
+        [InlineData(false, "NetCore31_A125b_FeatureSetToFalse", 0)]
+        [InlineData(true, "NetCore31_A125c_FeatureSetToTrue", 1)]
         public async Task Return_expected_for_inserted_key_value(
             bool? expected,
             string featureName,
@@ -73,6 +76,47 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
             Assert.NotEmpty(featureTableValues);
 
             var sut = CreateSut();
+            var result = await sut.GetAsync(featureName);
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData(null, "NetCore31_A349x_FeatureSetToNull", null)]
+        [InlineData(false, "NetCore31_A349y_FeatureSetToFalse", false)]
+        [InlineData(true, "NetCore31_A349z_FeatureSetToTrue", true)]
+        public async Task Return_expected_for_SetNullableValue(
+            bool? expected,
+            string featureName,
+            bool? enabled
+            )
+        {
+            var sut = CreateSut();
+            await sut.SetNullableAsync(featureName, enabled);
+
+            var featureTableValues = await _dbFixture.GetAllData();
+            Assert.NotEmpty(featureTableValues);
+
+            var result = await sut.GetAsync(featureName);
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData(null, "NetCore31_A359jx_FeatureSetToNull", null)]
+        [InlineData(false, "NetCore31_A359ky_FeatureSetToFalse", false)]
+        [InlineData(true, "NetCore31_A359lz_FeatureSetToTrue", true)]
+        public async Task Return_expected_for_SetValue(
+            bool? expected,
+            string featureName,
+            bool? enabled
+            )
+        {
+            var sut = CreateSut();
+            if (enabled.HasValue) await sut.SetAsync(featureName, enabled.Value);
+            else await sut.SetNullableAsync(featureName, null);
+
+            var featureTableValues = await _dbFixture.GetAllData();
+            Assert.NotEmpty(featureTableValues);
+
             var result = await sut.GetAsync(featureName);
             Assert.Equal(expected, result);
         }

--- a/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/Sql/SqlSessionManagerTests.cs
+++ b/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/Sql/SqlSessionManagerTests.cs
@@ -20,8 +20,10 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
         {
             return new SqlSessionManager(
                 settings: _dbFixture.SqlSessionManagerSettings,
-                getValueCommandFactory: s => _dbFixture.CreateGetValueCommand(s)
-            );
+                getValueCommandFactory: s => _dbFixture.CreateGetValueCommand(s),
+                setValueCommandFactory: (s, e) => _dbFixture.CreateSetValueCommand(s, e),
+                setNullableValueCommandFactory: (s, e) => _dbFixture.CreateSetNullableValueCommand(s, e)
+                );
         }
 
         [Fact]
@@ -33,9 +35,9 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
         }
 
         [Theory]
-        [InlineData(null, "A125a_FeatureSetToNull", null)]
-        [InlineData(false, "A125b_FeatureSetToFalse", 0)]
-        [InlineData(true, "A125c_FeatureSetToTrue", 1)]
+        [InlineData(null, "NetCore31_A125a_FeatureSetToNull", null)]
+        [InlineData(false, "NetCore31_A125b_FeatureSetToFalse", 0)]
+        [InlineData(true, "NetCore31_A125c_FeatureSetToTrue", 1)]
         public async Task Return_expected_for_inserted_key_value(
             bool? expected,
             string featureName,
@@ -66,6 +68,47 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
             Assert.NotEmpty(featureTableValues);
 
             var sut = CreateSut();
+            var result = await sut.GetAsync(featureName);
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData(null, "NetCore31_A129x_FeatureSetToNull", null)]
+        [InlineData(false, "NetCore31_A129y_FeatureSetToFalse", false)]
+        [InlineData(true, "NetCore31_A129z_FeatureSetToTrue", true)]
+        public async Task Return_expected_for_SetNullableValue(
+            bool? expected,
+            string featureName,
+            bool? enabled
+            )
+        {
+            var sut = CreateSut();
+            await sut.SetNullableAsync(featureName, enabled);
+
+            var featureTableValues = await _dbFixture.GetAllData();
+            Assert.NotEmpty(featureTableValues);
+
+            var result = await sut.GetAsync(featureName);
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData(null, "NetCore31_A139jx_FeatureSetToNull", null)]
+        [InlineData(false, "NetCore31_A139ky_FeatureSetToFalse", false)]
+        [InlineData(true, "NetCore31_A139lz_FeatureSetToTrue", true)]
+        public async Task Return_expected_for_SetValue(
+            bool? expected,
+            string featureName,
+            bool? enabled
+            )
+        {
+            var sut = CreateSut();
+            if (enabled.HasValue) await sut.SetAsync(featureName, enabled.Value);
+            else await sut.SetNullableAsync(featureName, null);
+
+            var featureTableValues = await _dbFixture.GetAllData();
+            Assert.NotEmpty(featureTableValues);
+
             var result = await sut.GetAsync(featureName);
             Assert.Equal(expected, result);
         }

--- a/tests/Lussatite.FeatureManagement.NetCore31.Tests/Testing/SQLite/SQLiteDatabaseFixture.cs
+++ b/tests/Lussatite.FeatureManagement.NetCore31.Tests/Testing/SQLite/SQLiteDatabaseFixture.cs
@@ -62,6 +62,49 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.Testing.SQLite
             return queryCommand;
         }
 
+        public DbCommand CreateSetNullableValueCommand(string featureName, bool? enabled)
+        {
+            var conn = new SQLiteConnection(connectionString);
+            conn.Open();
+
+            int? featureValue = null;
+            if (enabled.HasValue) featureValue = enabled.Value ? 1 : 0;
+            var queryCommand = conn.CreateCommand();
+            queryCommand.CommandText =
+                $@"
+                    INSERT INTO {TableName}
+                    ({NameColumn}, {ValueColumn})
+                    VALUES (@featureName, @featureValue)
+                    ON CONFLICT({NameColumn})
+                    DO UPDATE SET {ValueColumn}=@featureValue
+                ";
+            queryCommand.Parameters.Add(new SQLiteParameter("featureName", featureName));
+            queryCommand.Parameters.Add(new SQLiteParameter("@featureValue", featureValue));
+
+            return queryCommand;
+        }
+
+        public DbCommand CreateSetValueCommand(string featureName, bool enabled)
+        {
+            var conn = new SQLiteConnection(connectionString);
+            conn.Open();
+
+            var featureValue = enabled ? 1 : 0;
+            var queryCommand = conn.CreateCommand();
+            queryCommand.CommandText =
+                $@"
+                    INSERT INTO {TableName}
+                    ({NameColumn}, {ValueColumn})
+                    VALUES (@featureName, @featureValue)
+                    ON CONFLICT({NameColumn})
+                    DO UPDATE SET {ValueColumn}=@featureValue
+                ";
+            queryCommand.Parameters.Add(new SQLiteParameter("featureName", featureName));
+            queryCommand.Parameters.Add(new SQLiteParameter("@featureValue", featureValue));
+
+            return queryCommand;
+        }
+
         /// <summary>Meant to be used as a debug step, this returns all of the data in the table.</summary>
         public async Task<List<object[]>> GetAllData()
         {


### PR DESCRIPTION
- Add the ILussatiteSessionManager interface which inherits from the
ISessionManager interface and adds SetNullableAsync().  This method
does not get called by Microsoft IFeatureManager implementations, 
which makes it a safer way to set a value in the database table via
some out-of-band process such as a separate user-interface.

- Add "setValueCommandFactory" and "setNullableValueCommandFactory"
arguments to the constructor of SqlSessionManager.  These DbCommand
arguments, if not null, will enable writing back to the SQL database table
using SetAsync() and SetNullableAsync().

Note:  Most implementations should prefer to define the DbCommand for
SetNullableAsync() and use that from a separate UI instead of allowing
the database value to be set during execution of the Microsoft 
IFeatureManager.IsEnabledAsync implementation.