### PR TITLE
BUG: Look at total seconds, not seconds

### DIFF
--- a/src/Lussatite.FeatureManagement.SessionManagers/Sql/CachedSqlSessionManager.cs
+++ b/src/Lussatite.FeatureManagement.SessionManagers/Sql/CachedSqlSessionManager.cs
@@ -23,7 +23,7 @@ namespace Lussatite.FeatureManagement.SessionManagers
             )
         {
             _cachedSettings = settings ?? new CachedSqlSessionManagerSettings();
-            if (_cachedSettings.CacheTime.Seconds <= 0)
+            if (_cachedSettings.CacheTime.TotalSeconds <= 0)
                 throw new ArgumentOutOfRangeException(nameof(_cachedSettings.CacheTime));
             _cache = cache ?? new CachingService();
         }


### PR DESCRIPTION
This code caused a failure when a value of whole hours, minutes, days, etc.
were used for the TimeSpan.