### PR TITLE
Update exercise tests to not always call Set()

### DIFF
--- a/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Sql/CachedSqlSessionManagerTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Sql/CachedSqlSessionManagerTests.cs
@@ -127,14 +127,15 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         {
             var sut = CreateSut();
             const string baseName = "Net48_C997_ExerciseRepeatedly";
-            const int maxIterations = 250;
+            const int maxIterations = 1500;
             for (var i = 0; i < maxIterations; i++)
             {
+                var callSet = Rng.GetInteger(0, 20) == 0;
                 var value = Rng.GetNullableBoolean();
-                var featureName = $"{baseName}{Rng.GetInteger(0, 9)}";
-                await sut.SetNullableAsync(featureName, value);
+                var featureName = $"{baseName}{Rng.GetInteger(0, 10)}";
+                if (callSet) await sut.SetNullableAsync(featureName, value);
                 var result = await sut.GetAsync(featureName);
-                Assert.Equal(value, result);
+                if (callSet) Assert.Equal(value, result);
             }
         }
 
@@ -143,14 +144,15 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         {
             var sut = CreateSut();
             const string baseName = "Net48_C877_ExerciseRepeatedly";
-            const int maxIterations = 250;
+            const int maxIterations = 1500;
             for (var i = 0; i < maxIterations; i++)
             {
+                var callSet = Rng.GetInteger(0, 20) == 0;
                 var value = Rng.GetBoolean();
-                var featureName = $"{baseName}{Rng.GetInteger(0, 9)}";
-                await sut.SetAsync(featureName, value);
+                var featureName = $"{baseName}{Rng.GetInteger(0, 10)}";
+                if (callSet) await sut.SetAsync(featureName, value);
                 var result = await sut.GetAsync(featureName);
-                Assert.Equal(value, result);
+                if (callSet) Assert.Equal(value, result);
             }
         }
     }

--- a/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Sql/SqlSessionManagerTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Sql/SqlSessionManagerTests.cs
@@ -123,14 +123,15 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         {
             var sut = CreateSut();
             const string baseName = "Net48_A997_ExerciseRepeatedly";
-            const int maxIterations = 250;
+            const int maxIterations = 400;
             for (var i = 0; i < maxIterations; i++)
             {
+                var callSet = Rng.GetInteger(0, 20) == 0;
                 var value = Rng.GetNullableBoolean();
-                var featureName = $"{baseName}{Rng.GetInteger(0, 9)}";
-                await sut.SetNullableAsync(featureName, value);
+                var featureName = $"{baseName}{Rng.GetInteger(0, 10)}";
+                if (callSet) await sut.SetNullableAsync(featureName, value);
                 var result = await sut.GetAsync(featureName);
-                Assert.Equal(value, result);
+                if (callSet) Assert.Equal(value, result);
             }
         }
 
@@ -139,14 +140,15 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         {
             var sut = CreateSut();
             const string baseName = "Net48_A877_ExerciseRepeatedly";
-            const int maxIterations = 250;
+            const int maxIterations = 400;
             for (var i = 0; i < maxIterations; i++)
             {
+                var callSet = Rng.GetInteger(0, 20) == 0;
                 var value = Rng.GetBoolean();
-                var featureName = $"{baseName}{Rng.GetInteger(0, 9)}";
-                await sut.SetAsync(featureName, value);
+                var featureName = $"{baseName}{Rng.GetInteger(0, 10)}";
+                if (callSet) await sut.SetAsync(featureName, value);
                 var result = await sut.GetAsync(featureName);
-                Assert.Equal(value, result);
+                if (callSet) Assert.Equal(value, result);
             }
         }
     }

--- a/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Sql/CachedSqlSessionManagerTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Sql/CachedSqlSessionManagerTests.cs
@@ -124,14 +124,15 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
         {
             var sut = CreateSut();
             const string baseName = "Net6_C997_ExerciseRepeatedly";
-            const int maxIterations = 250;
+            const int maxIterations = 1500;
             for (var i = 0; i < maxIterations; i++)
             {
+                var callSet = Rng.GetInteger(0, 20) == 0;
                 var value = Rng.GetNullableBoolean();
-                var featureName = $"{baseName}{Rng.GetInteger(0, 9)}";
-                await sut.SetNullableAsync(featureName, value);
+                var featureName = $"{baseName}{Rng.GetInteger(0, 10)}";
+                if (callSet) await sut.SetNullableAsync(featureName, value);
                 var result = await sut.GetAsync(featureName);
-                Assert.Equal(value, result);
+                if (callSet) Assert.Equal(value, result);
             }
         }
 
@@ -140,14 +141,15 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
         {
             var sut = CreateSut();
             const string baseName = "Net6_C877_ExerciseRepeatedly";
-            const int maxIterations = 250;
+            const int maxIterations = 1500;
             for (var i = 0; i < maxIterations; i++)
             {
+                var callSet = Rng.GetInteger(0, 20) == 0;
                 var value = Rng.GetBoolean();
-                var featureName = $"{baseName}{Rng.GetInteger(0, 9)}";
-                await sut.SetAsync(featureName, value);
+                var featureName = $"{baseName}{Rng.GetInteger(0, 10)}";
+                if (callSet) await sut.SetAsync(featureName, value);
                 var result = await sut.GetAsync(featureName);
-                Assert.Equal(value, result);
+                if (callSet) Assert.Equal(value, result);
             }
         }
     }

--- a/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Sql/SqlSessionManagerTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Sql/SqlSessionManagerTests.cs
@@ -123,14 +123,15 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
         {
             var sut = CreateSut();
             const string baseName = "Net6_A997_ExerciseRepeatedly";
-            const int maxIterations = 250;
+            const int maxIterations = 400;
             for (var i = 0; i < maxIterations; i++)
             {
+                var callSet = Rng.GetInteger(0, 20) == 0;
                 var value = Rng.GetNullableBoolean();
-                var featureName = $"{baseName}{Rng.GetInteger(0, 9)}";
-                await sut.SetNullableAsync(featureName, value);
+                var featureName = $"{baseName}{Rng.GetInteger(0, 10)}";
+                if (callSet) await sut.SetNullableAsync(featureName, value);
                 var result = await sut.GetAsync(featureName);
-                Assert.Equal(value, result);
+                if (callSet) Assert.Equal(value, result);
             }
         }
 
@@ -139,14 +140,15 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
         {
             var sut = CreateSut();
             const string baseName = "Net6_A877_ExerciseRepeatedly";
-            const int maxIterations = 250;
+            const int maxIterations = 400;
             for (var i = 0; i < maxIterations; i++)
             {
+                var callSet = Rng.GetInteger(0, 20) == 0;
                 var value = Rng.GetBoolean();
-                var featureName = $"{baseName}{Rng.GetInteger(0, 9)}";
-                await sut.SetAsync(featureName, value);
+                var featureName = $"{baseName}{Rng.GetInteger(0, 10)}";
+                if (callSet) await sut.SetAsync(featureName, value);
                 var result = await sut.GetAsync(featureName);
-                Assert.Equal(value, result);
+                if (callSet) Assert.Equal(value, result);
             }
         }
     }

--- a/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/Sql/CachedSqlSessionManagerTests.cs
+++ b/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/Sql/CachedSqlSessionManagerTests.cs
@@ -124,14 +124,15 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
         {
             var sut = CreateSut();
             const string baseName = "NetCore31_C997_ExerciseRepeatedly";
-            const int maxIterations = 250;
+            const int maxIterations = 1500;
             for (var i = 0; i < maxIterations; i++)
             {
+                var callSet = Rng.GetInteger(0, 20) == 0;
                 var value = Rng.GetNullableBoolean();
-                var featureName = $"{baseName}{Rng.GetInteger(0, 9)}";
-                await sut.SetNullableAsync(featureName, value);
+                var featureName = $"{baseName}{Rng.GetInteger(0, 10)}";
+                if (callSet) await sut.SetNullableAsync(featureName, value);
                 var result = await sut.GetAsync(featureName);
-                Assert.Equal(value, result);
+                if (callSet) Assert.Equal(value, result);
             }
         }
 
@@ -140,14 +141,15 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
         {
             var sut = CreateSut();
             const string baseName = "NetCore31_C877_ExerciseRepeatedly";
-            const int maxIterations = 250;
+            const int maxIterations = 1500;
             for (var i = 0; i < maxIterations; i++)
             {
+                var callSet = Rng.GetInteger(0, 20) == 0;
                 var value = Rng.GetBoolean();
-                var featureName = $"{baseName}{Rng.GetInteger(0, 9)}";
-                await sut.SetAsync(featureName, value);
+                var featureName = $"{baseName}{Rng.GetInteger(0, 10)}";
+                if (callSet) await sut.SetAsync(featureName, value);
                 var result = await sut.GetAsync(featureName);
-                Assert.Equal(value, result);
+                if (callSet) Assert.Equal(value, result);
             }
         }
     }

--- a/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/Sql/SqlSessionManagerTests.cs
+++ b/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/Sql/SqlSessionManagerTests.cs
@@ -123,14 +123,15 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
         {
             var sut = CreateSut();
             const string baseName = "NetCore31_A997_ExerciseRepeatedly";
-            const int maxIterations = 250;
+            const int maxIterations = 400;
             for (var i = 0; i < maxIterations; i++)
             {
+                var callSet = Rng.GetInteger(0, 20) == 0;
                 var value = Rng.GetNullableBoolean();
-                var featureName = $"{baseName}{Rng.GetInteger(0, 9)}";
-                await sut.SetNullableAsync(featureName, value);
+                var featureName = $"{baseName}{Rng.GetInteger(0, 10)}";
+                if (callSet) await sut.SetNullableAsync(featureName, value);
                 var result = await sut.GetAsync(featureName);
-                Assert.Equal(value, result);
+                if (callSet) Assert.Equal(value, result);
             }
         }
 
@@ -139,14 +140,15 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
         {
             var sut = CreateSut();
             const string baseName = "NetCore31_A877_ExerciseRepeatedly";
-            const int maxIterations = 250;
+            const int maxIterations = 400;
             for (var i = 0; i < maxIterations; i++)
             {
+                var callSet = Rng.GetInteger(0, 20) == 0;
                 var value = Rng.GetBoolean();
-                var featureName = $"{baseName}{Rng.GetInteger(0, 9)}";
-                await sut.SetAsync(featureName, value);
+                var featureName = $"{baseName}{Rng.GetInteger(0, 10)}";
+                if (callSet) await sut.SetAsync(featureName, value);
                 var result = await sut.GetAsync(featureName);
-                Assert.Equal(value, result);
+                if (callSet) Assert.Equal(value, result);
             }
         }
     }

--- a/tests/TestCommon.Standard/Rng.cs
+++ b/tests/TestCommon.Standard/Rng.cs
@@ -8,7 +8,7 @@ namespace TestCommon.Standard
 
         public static bool? GetNullableBoolean()
         {
-            var result = Random.Next(-1, 1);
+            var result = Random.Next(-1, 2);
             switch (result)
             {
                 case 0: return false;
@@ -19,7 +19,7 @@ namespace TestCommon.Standard
 
         public static bool GetBoolean()
         {
-            var result = Random.Next(0, 1);
+            var result = Random.Next(0, 2);
             return result == 1;
         }
 


### PR DESCRIPTION
Only call the Set() method about 5% of the time (1:20 chance) to
more closely represent actual usage.  

Bump up the number of iterations to higher values.