### PR TITLE
Add per-GUID feature management table and SQL settings

### DIFF
--- a/src/Lussatite.FeatureManagement.SessionManagers.SqlClient/SQLServerPerGuidSessionManagerSettings.cs
+++ b/src/Lussatite.FeatureManagement.SessionManagers.SqlClient/SQLServerPerGuidSessionManagerSettings.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Data.SqlClient;
+using System.Threading.Tasks;
+
+namespace Lussatite.FeatureManagement.SessionManagers.SqlClient
+{
+    /// <summary>Default settings for a Microsoft SQL Server backend.  This one differs from
+    /// <see cref="SQLServerSessionManagerSettings"/> in that it uses a GUID to separate
+    /// out per-user feature values.  Note that if you use this with
+    /// <see cref="SqlSessionManager"/> or <see cref="CachedSqlSessionManager"/> that
+    /// everything needs to be registered as "scoped" / "per-request" in the DI container.</summary>
+    // ReSharper disable once InconsistentNaming
+    public class SQLServerPerGuidSessionManagerSettings : SqlSessionManagerSettings
+    {
+        public Guid UserGuid { get; set; }
+
+        protected override string DefaultTableName => "FeatureManagementByGuid";
+
+        private const string DefaultUserGuidColumn = "UserGuid";
+        private string _featureUserGuidColumn = DefaultUserGuidColumn;
+
+        /// <summary>The database column which contains the user (or session) GUID.</summary>
+        public string FeatureUserGuidColumn
+        {
+            get => string.IsNullOrEmpty(_featureUserGuidColumn) ? DefaultUserGuidColumn : _featureUserGuidColumn;
+            set
+            {
+                if (!IsValidColumnName(value))
+                    throw new Exception($"{nameof(FeatureUserGuidColumn)} set to invalid value.")
+                    {
+                        Data = { ["value"] = value }
+                    };
+
+                _featureUserGuidColumn = value;
+            }
+        }
+
+        /// <inheritdoc cref="GetConnectionFactory"/>
+        public override DbConnection GetConnectionFactory()
+        {
+            if (string.IsNullOrWhiteSpace(ConnectionString))
+                throw new Exception(
+                    $"Missing {nameof(ConnectionString)} value in {nameof(GetConnectionFactory)}()."
+                    );
+            return new SqlConnection(ConnectionString);
+        }
+
+        private string GetCreateDatabaseTableSql() =>
+            $@"
+if not exists
+    (select * from INFORMATION_SCHEMA.TABLES
+    where TABLE_SCHEMA = '{FeatureSchemaName}'
+    and TABLE_NAME = '{FeatureTableName}')
+begin
+  create table [{FeatureSchemaName}].[{FeatureTableName}]
+  (
+    [{FeatureUserGuidColumn}] UNIQUEIDENTIFIER not null,
+    [{FeatureNameColumn}] nvarchar(255) not null,
+    [{FeatureValueColumn}] bit,
+    [{FeatureCreatedColumn}] datetimeoffset DEFAULT GETUTCDATE(),
+    [{FeatureModifiedColumn}] datetimeoffset DEFAULT GETUTCDATE(),
+    CONSTRAINT PK_{FeatureTableName} PRIMARY KEY CLUSTERED ({FeatureUserGuidColumn},{FeatureNameColumn})
+  );
+end
+            ";
+
+        /// <inheritdoc cref="CreateDatabaseTable"/>
+        public override void CreateDatabaseTable(string tableCreateConnectionString)
+        {
+            if (string.IsNullOrWhiteSpace(tableCreateConnectionString))
+                throw new Exception($"{nameof(tableCreateConnectionString)} was not set.");
+
+            using (var conn = new SqlConnection(tableCreateConnectionString))
+            {
+                conn.Open();
+                using (var createCommand = conn.CreateCommand())
+                {
+                    createCommand.CommandText = GetCreateDatabaseTableSql();
+                    createCommand.ExecuteNonQuery();
+                }
+                conn.Close();
+            }
+        }
+
+        /// <inheritdoc cref="CreateDatabaseTableAsync"/>
+        public override async Task CreateDatabaseTableAsync(string tableCreateConnectionString)
+        {
+            if (string.IsNullOrWhiteSpace(tableCreateConnectionString))
+                throw new Exception($"{nameof(tableCreateConnectionString)} was not set.");
+
+            using (var conn = new SqlConnection(tableCreateConnectionString))
+            {
+                await conn.OpenAsync();
+                using (var createCommand = conn.CreateCommand())
+                {
+                    createCommand.CommandText = GetCreateDatabaseTableSql();
+                    await createCommand.ExecuteNonQueryAsync();
+                }
+                conn.Close();
+            }
+        }
+
+        /// <inheritdoc cref="GetValueDbCommand"/>
+        public override DbCommand GetValueDbCommand(string featureName)
+        {
+            var queryCommand = new SqlCommand();
+            queryCommand.CommandText =
+                $@"
+SELECT [{FeatureNameColumn}], [{FeatureValueColumn}]
+FROM [{FeatureSchemaName}].[{FeatureTableName}]
+WHERE [{FeatureUserGuidColumn}] = @userGuid and [{FeatureNameColumn}] = @featureName;
+                ";
+            queryCommand.Parameters.Add(new SqlParameter("userGuid", UserGuid));
+            queryCommand.Parameters.Add(new SqlParameter("featureName", featureName));
+            return queryCommand;
+        }
+
+        /// <inheritdoc cref="SetValueDbCommand"/>
+        public override DbCommand SetValueDbCommand(string featureName, bool enabled)
+        {
+            var queryCommand = new SqlCommand();
+
+            // https://sqlperformance.com/2020/09/locking/upsert-anti-pattern
+            queryCommand.CommandText =
+                $@"
+BEGIN TRANSACTION;
+
+UPDATE [{FeatureSchemaName}].[{FeatureTableName}] WITH (UPDLOCK, SERIALIZABLE)
+SET [{FeatureValueColumn}] = @featureEnabled, [{FeatureModifiedColumn}] = GETUTCDATE()
+WHERE [{FeatureUserGuidColumn}] = @userGuid and [{FeatureNameColumn}] = @featureName;
+
+IF @@ROWCOUNT = 0
+BEGIN
+  INSERT [{FeatureSchemaName}].[{FeatureTableName}]
+  ([{FeatureUserGuidColumn}], [{FeatureNameColumn}], [{FeatureValueColumn}])
+  VALUES (@userGuid, @featureName, @featureEnabled);
+END
+
+COMMIT TRANSACTION;
+                ";
+
+            queryCommand.Parameters.Add(new SqlParameter("userGuid", UserGuid));
+            queryCommand.Parameters.Add(new SqlParameter("featureName", featureName));
+            queryCommand.Parameters.Add(new SqlParameter("featureEnabled", enabled));
+
+            return queryCommand;
+        }
+
+        /// <inheritdoc cref="SetNullableValueDbCommand"/>
+        public override DbCommand SetNullableValueDbCommand(string featureName, bool? enabled)
+        {
+            var queryCommand = new SqlCommand();
+
+            // https://sqlperformance.com/2020/09/locking/upsert-anti-pattern
+            queryCommand.CommandText =
+                $@"
+BEGIN TRANSACTION;
+
+UPDATE [{FeatureSchemaName}].[{FeatureTableName}] WITH (UPDLOCK, SERIALIZABLE)
+SET [{FeatureValueColumn}] = @featureEnabled, [{FeatureModifiedColumn}] = GETUTCDATE()
+WHERE [{FeatureUserGuidColumn}] = @userGuid and [{FeatureNameColumn}] = @featureName;
+
+IF @@ROWCOUNT = 0
+BEGIN
+  INSERT [{FeatureSchemaName}].[{FeatureTableName}]
+  ([{FeatureUserGuidColumn}], [{FeatureNameColumn}], [{FeatureValueColumn}])
+  VALUES (@userGuid, @featureName, @featureEnabled);
+END
+
+COMMIT TRANSACTION;
+                ";
+
+            queryCommand.Parameters.Add(new SqlParameter("userGuid", UserGuid));
+            queryCommand.Parameters.Add(new SqlParameter("featureName", featureName));
+            queryCommand.Parameters.Add(new SqlParameter("featureEnabled", SqlDbType.Bit)
+            {
+                Value = (object) enabled ?? DBNull.Value,
+                IsNullable=true
+            });
+
+            return queryCommand;
+        }
+    }
+}

--- a/src/Lussatite.FeatureManagement.SessionManagers.SqlClient/SQLServerSessionManagerSettings.cs
+++ b/src/Lussatite.FeatureManagement.SessionManagers.SqlClient/SQLServerSessionManagerSettings.cs
@@ -82,7 +82,7 @@ end
                 $@"
 SELECT [{FeatureNameColumn}], [{FeatureValueColumn}]
 FROM [{FeatureSchemaName}].[{FeatureTableName}]
-WHERE {FeatureNameColumn} = @featureName;
+WHERE [{FeatureNameColumn}] = @featureName;
                 ";
             queryCommand.Parameters.Add(new SqlParameter("featureName", featureName));
             return queryCommand;

--- a/src/Lussatite.FeatureManagement.SessionManagers.SqlClient/SQLServerSessionManagerSettings.cs
+++ b/src/Lussatite.FeatureManagement.SessionManagers.SqlClient/SQLServerSessionManagerSettings.cs
@@ -33,7 +33,7 @@ begin
     [{FeatureValueColumn}] bit,
     [{FeatureCreatedColumn}] datetimeoffset DEFAULT GETUTCDATE(),
     [{FeatureModifiedColumn}] datetimeoffset DEFAULT GETUTCDATE(),
-    CONSTRAINT PK_{FeatureTableName}_{FeatureNameColumn} PRIMARY KEY CLUSTERED ({FeatureNameColumn})
+    CONSTRAINT PK_{FeatureTableName} PRIMARY KEY CLUSTERED ({FeatureNameColumn})
   )
 end
             ";

--- a/src/Lussatite.FeatureManagement.SessionManagers/Sql/SqlSessionManagerSettings.cs
+++ b/src/Lussatite.FeatureManagement.SessionManagers/Sql/SqlSessionManagerSettings.cs
@@ -9,15 +9,15 @@ namespace Lussatite.FeatureManagement.SessionManagers
     /// <summary>Settings class for the <see cref="SqlSessionManager"/> instance.</summary>
     public abstract class SqlSessionManagerSettings
     {
-        private string _featureSchemaName = DefaultSchemaName;
-        private string _featureTableName = DefaultTableName;
-        private string _featureNameColumn = DefaultNameColumn;
-        private string _featureValueColumn = DefaultValueColumn;
-        private string _featureCreatedColumn = DefaultCreatedColumn;
-        private string _featureModifiedColumn = DefaultModifiedColumn;
+        private string _featureSchemaName;
+        private string _featureTableName;
+        private string _featureNameColumn;
+        private string _featureValueColumn;
+        private string _featureCreatedColumn;
+        private string _featureModifiedColumn;
 
         private const string DefaultSchemaName = "dbo"; // not all SQL providers have the concept of schema
-        private const string DefaultTableName = "FeatureManagement";
+        protected virtual string DefaultTableName => "FeatureManagement";
         private const string DefaultNameColumn = "FeatureName";
         private const string DefaultValueColumn = "Enabled";
         private const string DefaultCreatedColumn = "Created";

--- a/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Sql/CachedSqlPerGuidSessionManagerSqlClientTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Sql/CachedSqlPerGuidSessionManagerSqlClientTests.cs
@@ -1,35 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
-using Lussatite.FeatureManagement.Net48.Tests.Testing.SQLite;
+using Lussatite.FeatureManagement.Net48.Tests.Testing.SQLServer;
 using Lussatite.FeatureManagement.SessionManagers;
 using TestCommon.Standard;
-using TestCommon.Standard.SQLite;
+using TestCommon.Standard.MicrosoftSQLServer;
 using Xunit;
 
 namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
 {
-    [Collection(nameof(SQLiteDatabaseCollection))]
-    public class SqlSessionManagerSQLiteTests
+    [Collection(nameof(SQLServerDatabaseCollection))]
+    public class CachedSqlPerGuidSessionManagerSqlClientTests
     {
-        private readonly SQLiteDatabaseFixture _dbFixture;
+        private readonly SqlServerDatabaseFixture _dbFixture;
+        private Guid PrimaryUser => _userGuids.First();
+        private readonly List<Guid> _userGuids = new List<Guid>();
+        private readonly Random _random = new Random();
 
-        public SqlSessionManagerSQLiteTests(SQLiteDatabaseFixture dbFixture)
+        public CachedSqlPerGuidSessionManagerSqlClientTests(SqlServerDatabaseFixture dbFixture)
         {
             _dbFixture = dbFixture;
+            for (var i = 0; i < 20; i++) _userGuids.Add(Guid.NewGuid());
+            _userSessionManagers = CreateSuts();
         }
 
-        private SqlSessionManager CreateSut()
+        private Guid GetRandomUserGuid()
         {
-            var settings = _dbFixture.SqlSessionManagerSettings;
-
-            return new SqlSessionManager(
-                settings: settings
-                );
+            var index = _random.Next(0, _userGuids.Count);
+            return _userGuids[index];
         }
+
+        private readonly IDictionary<Guid, SqlSessionManager> _userSessionManagers;
+
+        private IDictionary<Guid,SqlSessionManager> CreateSuts()
+        {
+            var baseSetting = _dbFixture.SQLServerPerGuidSessionManagerSettings;
+            var suts = new Dictionary<Guid, SqlSessionManager>();
+            foreach (var userGuid in _userGuids)
+            {
+                var setting = baseSetting.JsonClone();
+                setting.UserGuid = userGuid;
+                suts[userGuid] = new CachedSqlSessionManager(setting);
+            }
+
+            return suts;
+        }
+
+        private SqlSessionManager GetSutForUser(Guid userGuid) => _userSessionManagers[userGuid];
 
         [Fact]
         public async Task Return_null_for_nonexistent_key()
         {
-            var sut = CreateSut();
+            var sut = GetSutForUser(PrimaryUser);
             var result = await sut.GetAsync("someRandomFeatureNonExistentName");
             Assert.Null(result);
         }
@@ -44,7 +67,7 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
             bool? insertValue
             )
         {
-            var sut = CreateSut();
+            var sut = GetSutForUser(PrimaryUser);
             await sut.SetNullableAsync(featureName, insertValue);
 
             var featureTableValues = await _dbFixture.GetAllData(sut.Settings);
@@ -55,16 +78,16 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         }
 
         [Theory]
-        [InlineData(null, "Net48_A129x_FeatureSetToNull", null)]
-        [InlineData(false, "Net48_A129y_FeatureSetToFalse", false)]
-        [InlineData(true, "Net48_A129z_FeatureSetToTrue", true)]
+        [InlineData(null, "Net48_A349x_FeatureSetToNull", null)]
+        [InlineData(false, "Net48_A349y_FeatureSetToFalse", false)]
+        [InlineData(true, "Net48_A349z_FeatureSetToTrue", true)]
         public async Task Return_expected_for_SetNullableValue(
             bool? expected,
             string featureName,
             bool? enabled
             )
         {
-            var sut = CreateSut();
+            var sut = GetSutForUser(PrimaryUser);
             await sut.SetNullableAsync(featureName, enabled);
 
             var featureTableValues = await _dbFixture.GetAllData(sut.Settings);
@@ -75,16 +98,16 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         }
 
         [Theory]
-        [InlineData(null, "Net48_A139jx_FeatureSetToNull", null)]
-        [InlineData(false, "Net48_A139ky_FeatureSetToFalse", false)]
-        [InlineData(true, "Net48_A139lz_FeatureSetToTrue", true)]
+        [InlineData(null, "Net48_A359jx_FeatureSetToNull", null)]
+        [InlineData(false, "Net48_A359ky_FeatureSetToFalse", false)]
+        [InlineData(true, "Net48_A359lz_FeatureSetToTrue", true)]
         public async Task Return_expected_for_SetValue(
             bool? expected,
             string featureName,
             bool? enabled
             )
         {
-            var sut = CreateSut();
+            var sut = GetSutForUser(PrimaryUser);
             if (enabled.HasValue) await sut.SetAsync(featureName, enabled.Value);
             else await sut.SetNullableAsync(featureName, null);
 
@@ -98,11 +121,12 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         [Fact]
         public async Task Exercise_SetNullableValue()
         {
-            var sut = CreateSut();
-            const string baseName = "Net48_A997_ExerciseRepeatedly";
-            const int maxIterations = 500;
+            const string baseName = "Net48_C997_ExerciseRepeatedly";
+            const int maxIterations = 1500;
             for (var i = 0; i < maxIterations; i++)
             {
+                var userGuid = GetRandomUserGuid();
+                var sut = GetSutForUser(userGuid);
                 var callSet = Rng.GetInteger(0, 20) == 0;
                 var value = Rng.GetNullableBoolean();
                 var featureName = $"{baseName}{Rng.GetInteger(0, 10)}";
@@ -115,11 +139,12 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         [Fact]
         public async Task Exercise_SetValue()
         {
-            var sut = CreateSut();
-            const string baseName = "Net48_A877_ExerciseRepeatedly";
-            const int maxIterations = 500;
+            const string baseName = "Net48_C877_ExerciseRepeatedly";
+            const int maxIterations = 1500;
             for (var i = 0; i < maxIterations; i++)
             {
+                var userGuid = GetRandomUserGuid();
+                var sut = GetSutForUser(userGuid);
                 var callSet = Rng.GetInteger(0, 20) == 0;
                 var value = Rng.GetBoolean();
                 var featureName = $"{baseName}{Rng.GetInteger(0, 10)}";

--- a/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Sql/CachedSqlSessionManagerSQLiteTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Sql/CachedSqlSessionManagerSQLiteTests.cs
@@ -1,5 +1,4 @@
 using System.Threading.Tasks;
-using LazyCache;
 using Lussatite.FeatureManagement.Net48.Tests.Testing.SQLite;
 using Lussatite.FeatureManagement.SessionManagers;
 using TestCommon.Standard;

--- a/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Sql/CachedSqlSessionManagerSQLiteTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Sql/CachedSqlSessionManagerSQLiteTests.cs
@@ -47,7 +47,7 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
             var sut = CreateSut();
             await sut.SetNullableAsync(featureName, insertValue);
 
-            var featureTableValues = await _dbFixture.GetAllData();
+            var featureTableValues = await _dbFixture.GetAllData(sut.Settings);
             Assert.NotEmpty(featureTableValues);
 
             var result = await sut.GetAsync(featureName);
@@ -67,7 +67,7 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
             var sut = CreateSut();
             await sut.SetNullableAsync(featureName, enabled);
 
-            var featureTableValues = await _dbFixture.GetAllData();
+            var featureTableValues = await _dbFixture.GetAllData(sut.Settings);
             Assert.NotEmpty(featureTableValues);
 
             var result = await sut.GetAsync(featureName);
@@ -88,7 +88,7 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
             if (enabled.HasValue) await sut.SetAsync(featureName, enabled.Value);
             else await sut.SetNullableAsync(featureName, null);
 
-            var featureTableValues = await _dbFixture.GetAllData();
+            var featureTableValues = await _dbFixture.GetAllData(sut.Settings);
             Assert.NotEmpty(featureTableValues);
 
             var result = await sut.GetAsync(featureName);

--- a/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Sql/CachedSqlSessionManagerSqlClientTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Sql/CachedSqlSessionManagerSqlClientTests.cs
@@ -47,7 +47,7 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
             var sut = CreateSut();
             await sut.SetNullableAsync(featureName, insertValue);
 
-            var featureTableValues = await _dbFixture.GetAllData();
+            var featureTableValues = await _dbFixture.GetAllData(sut.Settings);
             Assert.NotEmpty(featureTableValues);
 
             var result = await sut.GetAsync(featureName);
@@ -67,7 +67,7 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
             var sut = CreateSut();
             await sut.SetNullableAsync(featureName, enabled);
 
-            var featureTableValues = await _dbFixture.GetAllData();
+            var featureTableValues = await _dbFixture.GetAllData(sut.Settings);
             Assert.NotEmpty(featureTableValues);
 
             var result = await sut.GetAsync(featureName);
@@ -88,7 +88,7 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
             if (enabled.HasValue) await sut.SetAsync(featureName, enabled.Value);
             else await sut.SetNullableAsync(featureName, null);
 
-            var featureTableValues = await _dbFixture.GetAllData();
+            var featureTableValues = await _dbFixture.GetAllData(sut.Settings);
             Assert.NotEmpty(featureTableValues);
 
             var result = await sut.GetAsync(featureName);

--- a/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Sql/CachedSqlSessionManagerSqlClientTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Sql/CachedSqlSessionManagerSqlClientTests.cs
@@ -1,5 +1,4 @@
 using System.Threading.Tasks;
-using LazyCache;
 using Lussatite.FeatureManagement.Net48.Tests.Testing.SQLServer;
 using Lussatite.FeatureManagement.SessionManagers;
 using TestCommon.Standard;

--- a/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Sql/SqlPerGuidSessionManagerSqlClientTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Sql/SqlPerGuidSessionManagerSqlClientTests.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Lussatite.FeatureManagement.Net48.Tests.Testing.SQLServer;
+using Lussatite.FeatureManagement.SessionManagers;
+using TestCommon.Standard;
+using TestCommon.Standard.MicrosoftSQLServer;
+using Xunit;
+
+namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
+{
+    [Collection(nameof(SQLServerDatabaseCollection))]
+    public class SqlPerGuidSessionManagerSqlClientTests
+    {
+        private readonly SqlServerDatabaseFixture _dbFixture;
+        private Guid PrimaryUser => _userGuids.First();
+        private readonly List<Guid> _userGuids = new List<Guid>();
+        private readonly Random _random = new Random();
+
+        private Guid GetRandomUserGuid()
+        {
+            var index = _random.Next(0, _userGuids.Count);
+            return _userGuids[index];
+        }
+
+        public SqlPerGuidSessionManagerSqlClientTests(SqlServerDatabaseFixture dbFixture)
+        {
+            _dbFixture = dbFixture;
+            for (var i = 0; i < 20; i++) _userGuids.Add(Guid.NewGuid());
+            _userSessionManagers = CreateSuts();
+        }
+
+        private readonly IDictionary<Guid, SqlSessionManager> _userSessionManagers;
+
+        private IDictionary<Guid,SqlSessionManager> CreateSuts()
+        {
+            var baseSetting = _dbFixture.SQLServerPerGuidSessionManagerSettings;
+            var suts = new Dictionary<Guid, SqlSessionManager>();
+            foreach (var userGuid in _userGuids)
+            {
+                var setting = baseSetting.JsonClone();
+                setting.UserGuid = userGuid;
+                suts[userGuid] = new SqlSessionManager(setting);
+            }
+
+            return suts;
+        }
+
+        private SqlSessionManager GetSutForUser(Guid userGuid) => _userSessionManagers[userGuid];
+
+        [Fact]
+        public async Task Return_null_for_nonexistent_key()
+        {
+            var sut = GetSutForUser(PrimaryUser);
+            var result = await sut.GetAsync("someRandomFeatureNonExistentName");
+            Assert.Null(result);
+        }
+
+        [Theory]
+        [InlineData(null, "Net48_M125a_FeatureSetToNull", null)]
+        [InlineData(false, "Net48_N125b_FeatureSetToFalse", false)]
+        [InlineData(true, "Net48_P125c_FeatureSetToTrue", true)]
+        public async Task Return_expected_for_inserted_key_value(
+            bool? expected,
+            string featureName,
+            bool? insertValue
+            )
+        {
+            var sut = GetSutForUser(PrimaryUser);
+            await sut.SetNullableAsync(featureName, insertValue);
+
+            var featureTableValues = await _dbFixture.GetAllData();
+            Assert.NotEmpty(featureTableValues);
+
+            var result = await sut.GetAsync(featureName);
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData(null, "Net48_J529x_FeatureSetToNull", null)]
+        [InlineData(false, "Net48_K329y_FeatureSetToFalse", false)]
+        [InlineData(true, "Net48_L729z_FeatureSetToTrue", true)]
+        public async Task Return_expected_for_SetNullableValue(
+            bool? expected,
+            string featureName,
+            bool? enabled
+            )
+        {
+            var sut = GetSutForUser(PrimaryUser);
+            await sut.SetNullableAsync(featureName, enabled);
+
+            var featureTableValues = await _dbFixture.GetAllData();
+            Assert.NotEmpty(featureTableValues);
+
+            var result = await sut.GetAsync(featureName);
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData(null, "Net48_D439jx_FeatureSetToNull", null)]
+        [InlineData(false, "Net48_E439ky_FeatureSetToFalse", false)]
+        [InlineData(true, "Net48_F439lz_FeatureSetToTrue", true)]
+        public async Task Return_expected_for_SetValue(
+            bool? expected,
+            string featureName,
+            bool? enabled
+            )
+        {
+            var sut = GetSutForUser(PrimaryUser);
+            if (enabled.HasValue) await sut.SetAsync(featureName, enabled.Value);
+            else await sut.SetNullableAsync(featureName, null);
+
+            var featureTableValues = await _dbFixture.GetAllData();
+            Assert.NotEmpty(featureTableValues);
+
+            var result = await sut.GetAsync(featureName);
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public async Task Exercise_SetNullableValue()
+        {
+            const string baseName = "Net48_B473_ExerciseRepeatedly";
+            const int maxIterations = 500;
+            for (var i = 0; i < maxIterations; i++)
+            {
+                var userGuid = GetRandomUserGuid();
+                var sut = GetSutForUser(userGuid);
+                var callSet = Rng.GetInteger(0, 20) == 0;
+                var value = Rng.GetNullableBoolean();
+                var featureName = $"{baseName}{Rng.GetInteger(0, 10)}";
+                if (callSet) await sut.SetNullableAsync(featureName, value);
+                var result = await sut.GetAsync(featureName);
+                if (callSet) Assert.Equal(value, result);
+            }
+        }
+
+        [Fact]
+        public async Task Exercise_SetValue()
+        {
+            const string baseName = "Net48_C985_ExerciseRepeatedly";
+            const int maxIterations = 500;
+            for (var i = 0; i < maxIterations; i++)
+            {
+                var userGuid = GetRandomUserGuid();
+                var sut = GetSutForUser(userGuid);
+                var callSet = Rng.GetInteger(0, 20) == 0;
+                var value = Rng.GetBoolean();
+                var featureName = $"{baseName}{Rng.GetInteger(0, 10)}";
+                if (callSet) await sut.SetAsync(featureName, value);
+                var result = await sut.GetAsync(featureName);
+                if (callSet) Assert.Equal(value, result);
+            }
+        }
+    }
+}

--- a/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Sql/SqlPerGuidSessionManagerSqlClientTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Sql/SqlPerGuidSessionManagerSqlClientTests.cs
@@ -70,7 +70,7 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
             var sut = GetSutForUser(PrimaryUser);
             await sut.SetNullableAsync(featureName, insertValue);
 
-            var featureTableValues = await _dbFixture.GetAllData();
+            var featureTableValues = await _dbFixture.GetAllData(sut.Settings);
             Assert.NotEmpty(featureTableValues);
 
             var result = await sut.GetAsync(featureName);
@@ -90,7 +90,7 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
             var sut = GetSutForUser(PrimaryUser);
             await sut.SetNullableAsync(featureName, enabled);
 
-            var featureTableValues = await _dbFixture.GetAllData();
+            var featureTableValues = await _dbFixture.GetAllData(sut.Settings);
             Assert.NotEmpty(featureTableValues);
 
             var result = await sut.GetAsync(featureName);
@@ -111,7 +111,7 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
             if (enabled.HasValue) await sut.SetAsync(featureName, enabled.Value);
             else await sut.SetNullableAsync(featureName, null);
 
-            var featureTableValues = await _dbFixture.GetAllData();
+            var featureTableValues = await _dbFixture.GetAllData(sut.Settings);
             Assert.NotEmpty(featureTableValues);
 
             var result = await sut.GetAsync(featureName);

--- a/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Sql/SqlSessionManagerSqlClientTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Sql/SqlSessionManagerSqlClientTests.cs
@@ -1,10 +1,8 @@
 using System.Threading.Tasks;
-using Lussatite.FeatureManagement.Net48.Tests.Testing.SQLite;
 using Lussatite.FeatureManagement.Net48.Tests.Testing.SQLServer;
 using Lussatite.FeatureManagement.SessionManagers;
 using TestCommon.Standard;
 using TestCommon.Standard.MicrosoftSQLServer;
-using TestCommon.Standard.SQLite;
 using Xunit;
 
 namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql

--- a/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Sql/SqlSessionManagerSqlClientTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Sql/SqlSessionManagerSqlClientTests.cs
@@ -47,7 +47,7 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
             var sut = CreateSut();
             await sut.SetNullableAsync(featureName, insertValue);
 
-            var featureTableValues = await _dbFixture.GetAllData();
+            var featureTableValues = await _dbFixture.GetAllData(sut.Settings);
             Assert.NotEmpty(featureTableValues);
 
             var result = await sut.GetAsync(featureName);
@@ -67,7 +67,7 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
             var sut = CreateSut();
             await sut.SetNullableAsync(featureName, enabled);
 
-            var featureTableValues = await _dbFixture.GetAllData();
+            var featureTableValues = await _dbFixture.GetAllData(sut.Settings);
             Assert.NotEmpty(featureTableValues);
 
             var result = await sut.GetAsync(featureName);
@@ -88,7 +88,7 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
             if (enabled.HasValue) await sut.SetAsync(featureName, enabled.Value);
             else await sut.SetNullableAsync(featureName, null);
 
-            var featureTableValues = await _dbFixture.GetAllData();
+            var featureTableValues = await _dbFixture.GetAllData(sut.Settings);
             Assert.NotEmpty(featureTableValues);
 
             var result = await sut.GetAsync(featureName);

--- a/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Sql/CachedSqlPerGuidSessionManagerSqlClientTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Sql/CachedSqlPerGuidSessionManagerSqlClientTests.cs
@@ -1,35 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
-using Lussatite.FeatureManagement.Net48.Tests.Testing.SQLite;
+using Lussatite.FeatureManagement.Net6.Tests.Testing.SQLServer;
 using Lussatite.FeatureManagement.SessionManagers;
 using TestCommon.Standard;
-using TestCommon.Standard.SQLite;
+using TestCommon.Standard.MicrosoftSQLServer;
 using Xunit;
 
-namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
+namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
 {
-    [Collection(nameof(SQLiteDatabaseCollection))]
-    public class SqlSessionManagerSQLiteTests
+    [Collection(nameof(SQLServerDatabaseCollection))]
+    public class CachedSqlPerGuidSessionManagerSqlClientTests
     {
-        private readonly SQLiteDatabaseFixture _dbFixture;
+        private readonly SqlServerDatabaseFixture _dbFixture;
+        private Guid PrimaryUser => _userGuids.First();
+        private readonly List<Guid> _userGuids = new List<Guid>();
+        private readonly Random _random = new Random();
 
-        public SqlSessionManagerSQLiteTests(SQLiteDatabaseFixture dbFixture)
+        public CachedSqlPerGuidSessionManagerSqlClientTests(SqlServerDatabaseFixture dbFixture)
         {
             _dbFixture = dbFixture;
+            for (var i = 0; i < 20; i++) _userGuids.Add(Guid.NewGuid());
+            _userSessionManagers = CreateSuts();
         }
 
-        private SqlSessionManager CreateSut()
+        private Guid GetRandomUserGuid()
         {
-            var settings = _dbFixture.SqlSessionManagerSettings;
-
-            return new SqlSessionManager(
-                settings: settings
-                );
+            var index = _random.Next(0, _userGuids.Count);
+            return _userGuids[index];
         }
+
+        private readonly IDictionary<Guid, SqlSessionManager> _userSessionManagers;
+
+        private IDictionary<Guid,SqlSessionManager> CreateSuts()
+        {
+            var baseSetting = _dbFixture.SQLServerPerGuidSessionManagerSettings;
+            var suts = new Dictionary<Guid, SqlSessionManager>();
+            foreach (var userGuid in _userGuids)
+            {
+                var setting = baseSetting.JsonClone();
+                setting.UserGuid = userGuid;
+                suts[userGuid] = new CachedSqlSessionManager(setting);
+            }
+
+            return suts;
+        }
+
+        private SqlSessionManager GetSutForUser(Guid userGuid) => _userSessionManagers[userGuid];
 
         [Fact]
         public async Task Return_null_for_nonexistent_key()
         {
-            var sut = CreateSut();
+            var sut = GetSutForUser(PrimaryUser);
             var result = await sut.GetAsync("someRandomFeatureNonExistentName");
             Assert.Null(result);
         }
@@ -44,7 +67,7 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
             bool? insertValue
             )
         {
-            var sut = CreateSut();
+            var sut = GetSutForUser(PrimaryUser);
             await sut.SetNullableAsync(featureName, insertValue);
 
             var featureTableValues = await _dbFixture.GetAllData(sut.Settings);
@@ -55,16 +78,16 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         }
 
         [Theory]
-        [InlineData(null, "Net48_A129x_FeatureSetToNull", null)]
-        [InlineData(false, "Net48_A129y_FeatureSetToFalse", false)]
-        [InlineData(true, "Net48_A129z_FeatureSetToTrue", true)]
+        [InlineData(null, "Net48_A349x_FeatureSetToNull", null)]
+        [InlineData(false, "Net48_A349y_FeatureSetToFalse", false)]
+        [InlineData(true, "Net48_A349z_FeatureSetToTrue", true)]
         public async Task Return_expected_for_SetNullableValue(
             bool? expected,
             string featureName,
             bool? enabled
             )
         {
-            var sut = CreateSut();
+            var sut = GetSutForUser(PrimaryUser);
             await sut.SetNullableAsync(featureName, enabled);
 
             var featureTableValues = await _dbFixture.GetAllData(sut.Settings);
@@ -75,16 +98,16 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         }
 
         [Theory]
-        [InlineData(null, "Net48_A139jx_FeatureSetToNull", null)]
-        [InlineData(false, "Net48_A139ky_FeatureSetToFalse", false)]
-        [InlineData(true, "Net48_A139lz_FeatureSetToTrue", true)]
+        [InlineData(null, "Net48_A359jx_FeatureSetToNull", null)]
+        [InlineData(false, "Net48_A359ky_FeatureSetToFalse", false)]
+        [InlineData(true, "Net48_A359lz_FeatureSetToTrue", true)]
         public async Task Return_expected_for_SetValue(
             bool? expected,
             string featureName,
             bool? enabled
             )
         {
-            var sut = CreateSut();
+            var sut = GetSutForUser(PrimaryUser);
             if (enabled.HasValue) await sut.SetAsync(featureName, enabled.Value);
             else await sut.SetNullableAsync(featureName, null);
 
@@ -98,11 +121,12 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         [Fact]
         public async Task Exercise_SetNullableValue()
         {
-            var sut = CreateSut();
-            const string baseName = "Net48_A997_ExerciseRepeatedly";
-            const int maxIterations = 500;
+            const string baseName = "Net48_C997_ExerciseRepeatedly";
+            const int maxIterations = 1500;
             for (var i = 0; i < maxIterations; i++)
             {
+                var userGuid = GetRandomUserGuid();
+                var sut = GetSutForUser(userGuid);
                 var callSet = Rng.GetInteger(0, 20) == 0;
                 var value = Rng.GetNullableBoolean();
                 var featureName = $"{baseName}{Rng.GetInteger(0, 10)}";
@@ -115,11 +139,12 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         [Fact]
         public async Task Exercise_SetValue()
         {
-            var sut = CreateSut();
-            const string baseName = "Net48_A877_ExerciseRepeatedly";
-            const int maxIterations = 500;
+            const string baseName = "Net48_C877_ExerciseRepeatedly";
+            const int maxIterations = 1500;
             for (var i = 0; i < maxIterations; i++)
             {
+                var userGuid = GetRandomUserGuid();
+                var sut = GetSutForUser(userGuid);
                 var callSet = Rng.GetInteger(0, 20) == 0;
                 var value = Rng.GetBoolean();
                 var featureName = $"{baseName}{Rng.GetInteger(0, 10)}";

--- a/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Sql/CachedSqlSessionManagerSQLiteTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Sql/CachedSqlSessionManagerSQLiteTests.cs
@@ -1,5 +1,4 @@
 using System.Threading.Tasks;
-using LazyCache;
 using Lussatite.FeatureManagement.Net6.Tests.Testing.SQLite;
 using Lussatite.FeatureManagement.SessionManagers;
 using TestCommon.Standard;

--- a/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Sql/CachedSqlSessionManagerSQLiteTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Sql/CachedSqlSessionManagerSQLiteTests.cs
@@ -48,7 +48,7 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
             var sut = CreateSut();
             await sut.SetNullableAsync(featureName, insertValue);
 
-            var featureTableValues = await _dbFixture.GetAllData();
+            var featureTableValues = await _dbFixture.GetAllData(sut.Settings);
             Assert.NotEmpty(featureTableValues);
 
             var result = await sut.GetAsync(featureName);
@@ -68,7 +68,7 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
             var sut = CreateSut();
             await sut.SetNullableAsync(featureName, enabled);
 
-            var featureTableValues = await _dbFixture.GetAllData();
+            var featureTableValues = await _dbFixture.GetAllData(sut.Settings);
             Assert.NotEmpty(featureTableValues);
 
             var result = await sut.GetAsync(featureName);
@@ -89,7 +89,7 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
             if (enabled.HasValue) await sut.SetAsync(featureName, enabled.Value);
             else await sut.SetNullableAsync(featureName, null);
 
-            var featureTableValues = await _dbFixture.GetAllData();
+            var featureTableValues = await _dbFixture.GetAllData(sut.Settings);
             Assert.NotEmpty(featureTableValues);
 
             var result = await sut.GetAsync(featureName);

--- a/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Sql/CachedSqlSessionManagerSqlClientTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Sql/CachedSqlSessionManagerSqlClientTests.cs
@@ -1,5 +1,4 @@
 using System.Threading.Tasks;
-using LazyCache;
 using Lussatite.FeatureManagement.Net6.Tests.Testing.SQLServer;
 using Lussatite.FeatureManagement.SessionManagers;
 using TestCommon.Standard;

--- a/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Sql/CachedSqlSessionManagerSqlClientTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Sql/CachedSqlSessionManagerSqlClientTests.cs
@@ -47,7 +47,7 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
             var sut = CreateSut();
             await sut.SetNullableAsync(featureName, insertValue);
 
-            var featureTableValues = await _dbFixture.GetAllData();
+            var featureTableValues = await _dbFixture.GetAllData(sut.Settings);
             Assert.NotEmpty(featureTableValues);
 
             var result = await sut.GetAsync(featureName);
@@ -67,7 +67,7 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
             var sut = CreateSut();
             await sut.SetNullableAsync(featureName, enabled);
 
-            var featureTableValues = await _dbFixture.GetAllData();
+            var featureTableValues = await _dbFixture.GetAllData(sut.Settings);
             Assert.NotEmpty(featureTableValues);
 
             var result = await sut.GetAsync(featureName);
@@ -88,7 +88,7 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
             if (enabled.HasValue) await sut.SetAsync(featureName, enabled.Value);
             else await sut.SetNullableAsync(featureName, null);
 
-            var featureTableValues = await _dbFixture.GetAllData();
+            var featureTableValues = await _dbFixture.GetAllData(sut.Settings);
             Assert.NotEmpty(featureTableValues);
 
             var result = await sut.GetAsync(featureName);

--- a/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Sql/SqlPerGuidSessionManagerSqlClientTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Sql/SqlPerGuidSessionManagerSqlClientTests.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Lussatite.FeatureManagement.Net6.Tests.Testing.SQLServer;
+using Lussatite.FeatureManagement.SessionManagers;
+using TestCommon.Standard;
+using TestCommon.Standard.MicrosoftSQLServer;
+using Xunit;
+
+namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
+{
+    [Collection(nameof(SQLServerDatabaseCollection))]
+    public class SqlPerGuidSessionManagerSqlClientTests
+    {
+        private readonly SqlServerDatabaseFixture _dbFixture;
+        private Guid PrimaryUser => _userGuids.First();
+        private readonly List<Guid> _userGuids = new List<Guid>();
+        private readonly Random _random = new Random();
+
+        private Guid GetRandomUserGuid()
+        {
+            var index = _random.Next(0, _userGuids.Count);
+            return _userGuids[index];
+        }
+
+        public SqlPerGuidSessionManagerSqlClientTests(SqlServerDatabaseFixture dbFixture)
+        {
+            _dbFixture = dbFixture;
+            for (var i = 0; i < 20; i++) _userGuids.Add(Guid.NewGuid());
+            _userSessionManagers = CreateSuts();
+        }
+
+        private readonly IDictionary<Guid, SqlSessionManager> _userSessionManagers;
+
+        private IDictionary<Guid,SqlSessionManager> CreateSuts()
+        {
+            var baseSetting = _dbFixture.SQLServerPerGuidSessionManagerSettings;
+            var suts = new Dictionary<Guid, SqlSessionManager>();
+            foreach (var userGuid in _userGuids)
+            {
+                var setting = baseSetting.JsonClone();
+                setting.UserGuid = userGuid;
+                suts[userGuid] = new SqlSessionManager(setting);
+            }
+
+            return suts;
+        }
+
+        private SqlSessionManager GetSutForUser(Guid userGuid) => _userSessionManagers[userGuid];
+
+        [Fact]
+        public async Task Return_null_for_nonexistent_key()
+        {
+            var sut = GetSutForUser(PrimaryUser);
+            var result = await sut.GetAsync("someRandomFeatureNonExistentName");
+            Assert.Null(result);
+        }
+
+        [Theory]
+        [InlineData(null, "Net48_M125a_FeatureSetToNull", null)]
+        [InlineData(false, "Net48_N125b_FeatureSetToFalse", false)]
+        [InlineData(true, "Net48_P125c_FeatureSetToTrue", true)]
+        public async Task Return_expected_for_inserted_key_value(
+            bool? expected,
+            string featureName,
+            bool? insertValue
+            )
+        {
+            var sut = GetSutForUser(PrimaryUser);
+            await sut.SetNullableAsync(featureName, insertValue);
+
+            var featureTableValues = await _dbFixture.GetAllData();
+            Assert.NotEmpty(featureTableValues);
+
+            var result = await sut.GetAsync(featureName);
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData(null, "Net48_J529x_FeatureSetToNull", null)]
+        [InlineData(false, "Net48_K329y_FeatureSetToFalse", false)]
+        [InlineData(true, "Net48_L729z_FeatureSetToTrue", true)]
+        public async Task Return_expected_for_SetNullableValue(
+            bool? expected,
+            string featureName,
+            bool? enabled
+            )
+        {
+            var sut = GetSutForUser(PrimaryUser);
+            await sut.SetNullableAsync(featureName, enabled);
+
+            var featureTableValues = await _dbFixture.GetAllData();
+            Assert.NotEmpty(featureTableValues);
+
+            var result = await sut.GetAsync(featureName);
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData(null, "Net48_D439jx_FeatureSetToNull", null)]
+        [InlineData(false, "Net48_E439ky_FeatureSetToFalse", false)]
+        [InlineData(true, "Net48_F439lz_FeatureSetToTrue", true)]
+        public async Task Return_expected_for_SetValue(
+            bool? expected,
+            string featureName,
+            bool? enabled
+            )
+        {
+            var sut = GetSutForUser(PrimaryUser);
+            if (enabled.HasValue) await sut.SetAsync(featureName, enabled.Value);
+            else await sut.SetNullableAsync(featureName, null);
+
+            var featureTableValues = await _dbFixture.GetAllData();
+            Assert.NotEmpty(featureTableValues);
+
+            var result = await sut.GetAsync(featureName);
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public async Task Exercise_SetNullableValue()
+        {
+            const string baseName = "Net48_B473_ExerciseRepeatedly";
+            const int maxIterations = 500;
+            for (var i = 0; i < maxIterations; i++)
+            {
+                var userGuid = GetRandomUserGuid();
+                var sut = GetSutForUser(userGuid);
+                var callSet = Rng.GetInteger(0, 20) == 0;
+                var value = Rng.GetNullableBoolean();
+                var featureName = $"{baseName}{Rng.GetInteger(0, 10)}";
+                if (callSet) await sut.SetNullableAsync(featureName, value);
+                var result = await sut.GetAsync(featureName);
+                if (callSet) Assert.Equal(value, result);
+            }
+        }
+
+        [Fact]
+        public async Task Exercise_SetValue()
+        {
+            const string baseName = "Net48_C985_ExerciseRepeatedly";
+            const int maxIterations = 500;
+            for (var i = 0; i < maxIterations; i++)
+            {
+                var userGuid = GetRandomUserGuid();
+                var sut = GetSutForUser(userGuid);
+                var callSet = Rng.GetInteger(0, 20) == 0;
+                var value = Rng.GetBoolean();
+                var featureName = $"{baseName}{Rng.GetInteger(0, 10)}";
+                if (callSet) await sut.SetAsync(featureName, value);
+                var result = await sut.GetAsync(featureName);
+                if (callSet) Assert.Equal(value, result);
+            }
+        }
+    }
+}

--- a/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Sql/SqlPerGuidSessionManagerSqlClientTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Sql/SqlPerGuidSessionManagerSqlClientTests.cs
@@ -70,7 +70,7 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
             var sut = GetSutForUser(PrimaryUser);
             await sut.SetNullableAsync(featureName, insertValue);
 
-            var featureTableValues = await _dbFixture.GetAllData();
+            var featureTableValues = await _dbFixture.GetAllData(sut.Settings);
             Assert.NotEmpty(featureTableValues);
 
             var result = await sut.GetAsync(featureName);
@@ -90,7 +90,7 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
             var sut = GetSutForUser(PrimaryUser);
             await sut.SetNullableAsync(featureName, enabled);
 
-            var featureTableValues = await _dbFixture.GetAllData();
+            var featureTableValues = await _dbFixture.GetAllData(sut.Settings);
             Assert.NotEmpty(featureTableValues);
 
             var result = await sut.GetAsync(featureName);
@@ -111,7 +111,7 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
             if (enabled.HasValue) await sut.SetAsync(featureName, enabled.Value);
             else await sut.SetNullableAsync(featureName, null);
 
-            var featureTableValues = await _dbFixture.GetAllData();
+            var featureTableValues = await _dbFixture.GetAllData(sut.Settings);
             Assert.NotEmpty(featureTableValues);
 
             var result = await sut.GetAsync(featureName);

--- a/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Sql/SqlSessionManagerSQLiteTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Sql/SqlSessionManagerSQLiteTests.cs
@@ -47,7 +47,7 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
             var sut = CreateSut();
             await sut.SetNullableAsync(featureName, insertValue);
 
-            var featureTableValues = await _dbFixture.GetAllData();
+            var featureTableValues = await _dbFixture.GetAllData(sut.Settings);
             Assert.NotEmpty(featureTableValues);
 
             var result = await sut.GetAsync(featureName);
@@ -67,7 +67,7 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
             var sut = CreateSut();
             await sut.SetNullableAsync(featureName, enabled);
 
-            var featureTableValues = await _dbFixture.GetAllData();
+            var featureTableValues = await _dbFixture.GetAllData(sut.Settings);
             Assert.NotEmpty(featureTableValues);
 
             var result = await sut.GetAsync(featureName);
@@ -88,7 +88,7 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
             if (enabled.HasValue) await sut.SetAsync(featureName, enabled.Value);
             else await sut.SetNullableAsync(featureName, null);
 
-            var featureTableValues = await _dbFixture.GetAllData();
+            var featureTableValues = await _dbFixture.GetAllData(sut.Settings);
             Assert.NotEmpty(featureTableValues);
 
             var result = await sut.GetAsync(featureName);

--- a/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Sql/SqlSessionManagerSqlClientTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Sql/SqlSessionManagerSqlClientTests.cs
@@ -47,7 +47,7 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
             var sut = CreateSut();
             await sut.SetNullableAsync(featureName, insertValue);
 
-            var featureTableValues = await _dbFixture.GetAllData();
+            var featureTableValues = await _dbFixture.GetAllData(sut.Settings);
             Assert.NotEmpty(featureTableValues);
 
             var result = await sut.GetAsync(featureName);
@@ -67,7 +67,7 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
             var sut = CreateSut();
             await sut.SetNullableAsync(featureName, enabled);
 
-            var featureTableValues = await _dbFixture.GetAllData();
+            var featureTableValues = await _dbFixture.GetAllData(sut.Settings);
             Assert.NotEmpty(featureTableValues);
 
             var result = await sut.GetAsync(featureName);
@@ -88,7 +88,7 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
             if (enabled.HasValue) await sut.SetAsync(featureName, enabled.Value);
             else await sut.SetNullableAsync(featureName, null);
 
-            var featureTableValues = await _dbFixture.GetAllData();
+            var featureTableValues = await _dbFixture.GetAllData(sut.Settings);
             Assert.NotEmpty(featureTableValues);
 
             var result = await sut.GetAsync(featureName);

--- a/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/Sql/CachedSqlSessionManagerSQLiteTests.cs
+++ b/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/Sql/CachedSqlSessionManagerSQLiteTests.cs
@@ -1,5 +1,4 @@
 using System.Threading.Tasks;
-using LazyCache;
 using Lussatite.FeatureManagement.NetCore31.Tests.Testing.SQLite;
 using Lussatite.FeatureManagement.SessionManagers;
 using TestCommon.Standard;

--- a/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/Sql/CachedSqlSessionManagerSQLiteTests.cs
+++ b/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/Sql/CachedSqlSessionManagerSQLiteTests.cs
@@ -48,7 +48,7 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
             var sut = CreateSut();
             await sut.SetNullableAsync(featureName, insertValue);
 
-            var featureTableValues = await _dbFixture.GetAllData();
+            var featureTableValues = await _dbFixture.GetAllData(sut.Settings);
             Assert.NotEmpty(featureTableValues);
 
             var result = await sut.GetAsync(featureName);
@@ -68,7 +68,7 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
             var sut = CreateSut();
             await sut.SetNullableAsync(featureName, enabled);
 
-            var featureTableValues = await _dbFixture.GetAllData();
+            var featureTableValues = await _dbFixture.GetAllData(sut.Settings);
             Assert.NotEmpty(featureTableValues);
 
             var result = await sut.GetAsync(featureName);
@@ -89,7 +89,7 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
             if (enabled.HasValue) await sut.SetAsync(featureName, enabled.Value);
             else await sut.SetNullableAsync(featureName, null);
 
-            var featureTableValues = await _dbFixture.GetAllData();
+            var featureTableValues = await _dbFixture.GetAllData(sut.Settings);
             Assert.NotEmpty(featureTableValues);
 
             var result = await sut.GetAsync(featureName);

--- a/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/Sql/CachedSqlSessionManagerSqlClientTests.cs
+++ b/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/Sql/CachedSqlSessionManagerSqlClientTests.cs
@@ -1,5 +1,4 @@
 using System.Threading.Tasks;
-using LazyCache;
 using Lussatite.FeatureManagement.NetCore31.Tests.Testing.SQLServer;
 using Lussatite.FeatureManagement.SessionManagers;
 using TestCommon.Standard;

--- a/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/Sql/CachedSqlSessionManagerSqlClientTests.cs
+++ b/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/Sql/CachedSqlSessionManagerSqlClientTests.cs
@@ -47,7 +47,7 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
             var sut = CreateSut();
             await sut.SetNullableAsync(featureName, insertValue);
 
-            var featureTableValues = await _dbFixture.GetAllData();
+            var featureTableValues = await _dbFixture.GetAllData(sut.Settings);
             Assert.NotEmpty(featureTableValues);
 
             var result = await sut.GetAsync(featureName);
@@ -67,7 +67,7 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
             var sut = CreateSut();
             await sut.SetNullableAsync(featureName, enabled);
 
-            var featureTableValues = await _dbFixture.GetAllData();
+            var featureTableValues = await _dbFixture.GetAllData(sut.Settings);
             Assert.NotEmpty(featureTableValues);
 
             var result = await sut.GetAsync(featureName);
@@ -88,7 +88,7 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
             if (enabled.HasValue) await sut.SetAsync(featureName, enabled.Value);
             else await sut.SetNullableAsync(featureName, null);
 
-            var featureTableValues = await _dbFixture.GetAllData();
+            var featureTableValues = await _dbFixture.GetAllData(sut.Settings);
             Assert.NotEmpty(featureTableValues);
 
             var result = await sut.GetAsync(featureName);

--- a/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/Sql/SqlPerGuidSessionManagerSqlClientTests.cs
+++ b/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/Sql/SqlPerGuidSessionManagerSqlClientTests.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Lussatite.FeatureManagement.NetCore31.Tests.Testing.SQLServer;
+using Lussatite.FeatureManagement.SessionManagers;
+using TestCommon.Standard;
+using TestCommon.Standard.MicrosoftSQLServer;
+using Xunit;
+
+namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
+{
+    [Collection(nameof(SQLServerDatabaseCollection))]
+    public class SqlPerGuidSessionManagerSqlClientTests
+    {
+        private readonly SqlServerDatabaseFixture _dbFixture;
+        private Guid PrimaryUser => _userGuids.First();
+        private readonly List<Guid> _userGuids = new List<Guid>();
+        private readonly Random _random = new Random();
+
+        private Guid GetRandomUserGuid()
+        {
+            var index = _random.Next(0, _userGuids.Count);
+            return _userGuids[index];
+        }
+
+        public SqlPerGuidSessionManagerSqlClientTests(SqlServerDatabaseFixture dbFixture)
+        {
+            _dbFixture = dbFixture;
+            for (var i = 0; i < 20; i++) _userGuids.Add(Guid.NewGuid());
+            _userSessionManagers = CreateSuts();
+        }
+
+        private readonly IDictionary<Guid, SqlSessionManager> _userSessionManagers;
+
+        private IDictionary<Guid,SqlSessionManager> CreateSuts()
+        {
+            var baseSetting = _dbFixture.SQLServerPerGuidSessionManagerSettings;
+            var suts = new Dictionary<Guid, SqlSessionManager>();
+            foreach (var userGuid in _userGuids)
+            {
+                var setting = baseSetting.JsonClone();
+                setting.UserGuid = userGuid;
+                suts[userGuid] = new SqlSessionManager(setting);
+            }
+
+            return suts;
+        }
+
+        private SqlSessionManager GetSutForUser(Guid userGuid) => _userSessionManagers[userGuid];
+
+        [Fact]
+        public async Task Return_null_for_nonexistent_key()
+        {
+            var sut = GetSutForUser(PrimaryUser);
+            var result = await sut.GetAsync("someRandomFeatureNonExistentName");
+            Assert.Null(result);
+        }
+
+        [Theory]
+        [InlineData(null, "Net48_M125a_FeatureSetToNull", null)]
+        [InlineData(false, "Net48_N125b_FeatureSetToFalse", false)]
+        [InlineData(true, "Net48_P125c_FeatureSetToTrue", true)]
+        public async Task Return_expected_for_inserted_key_value(
+            bool? expected,
+            string featureName,
+            bool? insertValue
+            )
+        {
+            var sut = GetSutForUser(PrimaryUser);
+            await sut.SetNullableAsync(featureName, insertValue);
+
+            var featureTableValues = await _dbFixture.GetAllData();
+            Assert.NotEmpty(featureTableValues);
+
+            var result = await sut.GetAsync(featureName);
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData(null, "Net48_J529x_FeatureSetToNull", null)]
+        [InlineData(false, "Net48_K329y_FeatureSetToFalse", false)]
+        [InlineData(true, "Net48_L729z_FeatureSetToTrue", true)]
+        public async Task Return_expected_for_SetNullableValue(
+            bool? expected,
+            string featureName,
+            bool? enabled
+            )
+        {
+            var sut = GetSutForUser(PrimaryUser);
+            await sut.SetNullableAsync(featureName, enabled);
+
+            var featureTableValues = await _dbFixture.GetAllData();
+            Assert.NotEmpty(featureTableValues);
+
+            var result = await sut.GetAsync(featureName);
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData(null, "Net48_D439jx_FeatureSetToNull", null)]
+        [InlineData(false, "Net48_E439ky_FeatureSetToFalse", false)]
+        [InlineData(true, "Net48_F439lz_FeatureSetToTrue", true)]
+        public async Task Return_expected_for_SetValue(
+            bool? expected,
+            string featureName,
+            bool? enabled
+            )
+        {
+            var sut = GetSutForUser(PrimaryUser);
+            if (enabled.HasValue) await sut.SetAsync(featureName, enabled.Value);
+            else await sut.SetNullableAsync(featureName, null);
+
+            var featureTableValues = await _dbFixture.GetAllData();
+            Assert.NotEmpty(featureTableValues);
+
+            var result = await sut.GetAsync(featureName);
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public async Task Exercise_SetNullableValue()
+        {
+            const string baseName = "Net48_B473_ExerciseRepeatedly";
+            const int maxIterations = 500;
+            for (var i = 0; i < maxIterations; i++)
+            {
+                var userGuid = GetRandomUserGuid();
+                var sut = GetSutForUser(userGuid);
+                var callSet = Rng.GetInteger(0, 20) == 0;
+                var value = Rng.GetNullableBoolean();
+                var featureName = $"{baseName}{Rng.GetInteger(0, 10)}";
+                if (callSet) await sut.SetNullableAsync(featureName, value);
+                var result = await sut.GetAsync(featureName);
+                if (callSet) Assert.Equal(value, result);
+            }
+        }
+
+        [Fact]
+        public async Task Exercise_SetValue()
+        {
+            const string baseName = "Net48_C985_ExerciseRepeatedly";
+            const int maxIterations = 500;
+            for (var i = 0; i < maxIterations; i++)
+            {
+                var userGuid = GetRandomUserGuid();
+                var sut = GetSutForUser(userGuid);
+                var callSet = Rng.GetInteger(0, 20) == 0;
+                var value = Rng.GetBoolean();
+                var featureName = $"{baseName}{Rng.GetInteger(0, 10)}";
+                if (callSet) await sut.SetAsync(featureName, value);
+                var result = await sut.GetAsync(featureName);
+                if (callSet) Assert.Equal(value, result);
+            }
+        }
+    }
+}

--- a/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/Sql/SqlPerGuidSessionManagerSqlClientTests.cs
+++ b/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/Sql/SqlPerGuidSessionManagerSqlClientTests.cs
@@ -70,7 +70,7 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
             var sut = GetSutForUser(PrimaryUser);
             await sut.SetNullableAsync(featureName, insertValue);
 
-            var featureTableValues = await _dbFixture.GetAllData();
+            var featureTableValues = await _dbFixture.GetAllData(sut.Settings);
             Assert.NotEmpty(featureTableValues);
 
             var result = await sut.GetAsync(featureName);
@@ -90,7 +90,7 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
             var sut = GetSutForUser(PrimaryUser);
             await sut.SetNullableAsync(featureName, enabled);
 
-            var featureTableValues = await _dbFixture.GetAllData();
+            var featureTableValues = await _dbFixture.GetAllData(sut.Settings);
             Assert.NotEmpty(featureTableValues);
 
             var result = await sut.GetAsync(featureName);
@@ -111,7 +111,7 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
             if (enabled.HasValue) await sut.SetAsync(featureName, enabled.Value);
             else await sut.SetNullableAsync(featureName, null);
 
-            var featureTableValues = await _dbFixture.GetAllData();
+            var featureTableValues = await _dbFixture.GetAllData(sut.Settings);
             Assert.NotEmpty(featureTableValues);
 
             var result = await sut.GetAsync(featureName);

--- a/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/Sql/SqlSessionManagerSQLiteTests.cs
+++ b/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/Sql/SqlSessionManagerSQLiteTests.cs
@@ -47,7 +47,7 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
             var sut = CreateSut();
             await sut.SetNullableAsync(featureName, insertValue);
 
-            var featureTableValues = await _dbFixture.GetAllData();
+            var featureTableValues = await _dbFixture.GetAllData(sut.Settings);
             Assert.NotEmpty(featureTableValues);
 
             var result = await sut.GetAsync(featureName);
@@ -67,7 +67,7 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
             var sut = CreateSut();
             await sut.SetNullableAsync(featureName, enabled);
 
-            var featureTableValues = await _dbFixture.GetAllData();
+            var featureTableValues = await _dbFixture.GetAllData(sut.Settings);
             Assert.NotEmpty(featureTableValues);
 
             var result = await sut.GetAsync(featureName);
@@ -88,7 +88,7 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
             if (enabled.HasValue) await sut.SetAsync(featureName, enabled.Value);
             else await sut.SetNullableAsync(featureName, null);
 
-            var featureTableValues = await _dbFixture.GetAllData();
+            var featureTableValues = await _dbFixture.GetAllData(sut.Settings);
             Assert.NotEmpty(featureTableValues);
 
             var result = await sut.GetAsync(featureName);

--- a/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/Sql/SqlSessionManagerSqlClientTests.cs
+++ b/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/Sql/SqlSessionManagerSqlClientTests.cs
@@ -47,7 +47,7 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
             var sut = CreateSut();
             await sut.SetNullableAsync(featureName, insertValue);
 
-            var featureTableValues = await _dbFixture.GetAllData();
+            var featureTableValues = await _dbFixture.GetAllData(sut.Settings);
             Assert.NotEmpty(featureTableValues);
 
             var result = await sut.GetAsync(featureName);
@@ -67,7 +67,7 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
             var sut = CreateSut();
             await sut.SetNullableAsync(featureName, enabled);
 
-            var featureTableValues = await _dbFixture.GetAllData();
+            var featureTableValues = await _dbFixture.GetAllData(sut.Settings);
             Assert.NotEmpty(featureTableValues);
 
             var result = await sut.GetAsync(featureName);
@@ -88,7 +88,7 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
             if (enabled.HasValue) await sut.SetAsync(featureName, enabled.Value);
             else await sut.SetNullableAsync(featureName, null);
 
-            var featureTableValues = await _dbFixture.GetAllData();
+            var featureTableValues = await _dbFixture.GetAllData(sut.Settings);
             Assert.NotEmpty(featureTableValues);
 
             var result = await sut.GetAsync(featureName);

--- a/tests/TestCommon.Standard/MicrosoftSQLServer/SQLServerDatabaseFixture.cs
+++ b/tests/TestCommon.Standard/MicrosoftSQLServer/SQLServerDatabaseFixture.cs
@@ -192,16 +192,16 @@ namespace TestCommon.Standard.MicrosoftSQLServer
         }
 
         /// <summary>Meant to be used as a debug step, this returns all of the data in the table.</summary>
-        public async Task<List<object[]>> GetAllData()
+        public async Task<List<object[]>> GetAllData(SqlSessionManagerSettings settings)
         {
             var result = new List<object[]>();
-            using (var conn = new SqlConnection(SqlSessionManagerSettings.ConnectionString))
+            using (var conn = new SqlConnection(settings.ConnectionString))
             {
                 conn.Open();
                 using (var cmd = conn.CreateCommand())
                 {
                     cmd.Connection = conn;
-                    cmd.CommandText = $@"SELECT * FROM {SqlSessionManagerSettings.FeatureTableName};";
+                    cmd.CommandText = $@"SELECT * FROM {settings.FeatureTableName};";
                     using (var reader = await cmd.ExecuteReaderAsync().ConfigureAwait(false))
                     {
                         while (reader.Read())

--- a/tests/TestCommon.Standard/MicrosoftSQLServer/SQLServerDatabaseFixture.cs
+++ b/tests/TestCommon.Standard/MicrosoftSQLServer/SQLServerDatabaseFixture.cs
@@ -12,6 +12,7 @@ namespace TestCommon.Standard.MicrosoftSQLServer
 {
     public class SqlServerDatabaseFixture : IDisposable
     {
+        public SQLServerPerGuidSessionManagerSettings SQLServerPerGuidSessionManagerSettings { get; }
         public SqlSessionManagerSettings SqlSessionManagerSettings { get; }
         public string DbName { get; }
 
@@ -32,12 +33,18 @@ namespace TestCommon.Standard.MicrosoftSQLServer
             SqlSessionManagerSettings = new SQLServerSessionManagerSettings
             {
                 ConnectionString = connectionString,
+                EnableSetValueCommand = true,
+            };
 
+            SQLServerPerGuidSessionManagerSettings = new SQLServerPerGuidSessionManagerSettings
+            {
+                ConnectionString = connectionString,
                 EnableSetValueCommand = true,
             };
 
             CreateDatabase();
             SqlSessionManagerSettings.CreateDatabaseTable(connectionString);
+            SQLServerPerGuidSessionManagerSettings.CreateDatabaseTable(connectionString);
         }
 
         private static readonly Random Random = new Random();

--- a/tests/TestCommon.Standard/ObjectCopier.cs
+++ b/tests/TestCommon.Standard/ObjectCopier.cs
@@ -1,0 +1,36 @@
+using Newtonsoft.Json;
+
+namespace TestCommon.Standard
+{
+    public static class ObjectCopier
+    {
+        // https://stackoverflow.com/a/52057700
+
+        /// <summary>
+        /// Perform a deep Copy of the object, using Json as a serialisation method.
+        /// NOTE: Private members are not cloned using this method.
+        /// </summary>
+        /// <typeparam name="T">The type of object being copied.</typeparam>
+        /// <param name="source">The object instance to copy.</param>
+        /// <returns>The copied object.</returns>
+        public static T JsonClone<T>(this T source)
+        {
+            // Don't serialize a null object, simply return the default for that object
+            if (object.ReferenceEquals(source, null))
+            {
+                return default(T);
+            }
+
+            // initialize inner objects individually
+            // for example in default constructor some list property initialized with some values,
+            // but in 'source' these items are cleaned -
+            // without ObjectCreationHandling.Replace default constructor values will be added to result
+            var deserializeSettings = new JsonSerializerSettings
+            {
+                ObjectCreationHandling = ObjectCreationHandling.Replace
+            };
+
+            return JsonConvert.DeserializeObject<T>(JsonConvert.SerializeObject(source), deserializeSettings);
+        }
+    }
+}

--- a/tests/TestCommon.Standard/SQLite/SQLiteDatabaseFixture.cs
+++ b/tests/TestCommon.Standard/SQLite/SQLiteDatabaseFixture.cs
@@ -36,16 +36,16 @@ namespace TestCommon.Standard.SQLite
         }
 
         /// <summary>Meant to be used as a debug step, this returns all of the data in the table.</summary>
-        public async Task<List<object[]>> GetAllData()
+        public async Task<List<object[]>> GetAllData(SqlSessionManagerSettings settings)
         {
             var result = new List<object[]>();
-            using (var conn = new SQLiteConnection(SqlSessionManagerSettings.ConnectionString))
+            using (var conn = new SQLiteConnection(settings.ConnectionString))
             {
                 conn.Open();
                 using (var cmd = conn.CreateCommand())
                 {
                     cmd.Connection = conn;
-                    cmd.CommandText = $@"SELECT * FROM {SqlSessionManagerSettings.FeatureTableName};";
+                    cmd.CommandText = $@"SELECT * FROM {settings.FeatureTableName};";
                     using (var reader = await cmd.ExecuteReaderAsync().ConfigureAwait(false))
                     {
                         while (reader.Read())

--- a/tests/TestCommon.Standard/TestCommon.Standard.csproj
+++ b/tests/TestCommon.Standard/TestCommon.Standard.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.20" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.20" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.20" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.3" />
     <PackageReference Include="System.Data.SQLite" Version="1.0.115.5" />
   </ItemGroup>


### PR DESCRIPTION
Add a `SqlSessionManagerSettings` child class called `SQLServerPerGuidSessionManagerSettings` which can be used to store per-GUID feature flag values.  

A common use-case would be users/groups which are defined by a GUID; letting you have different feature flag values for each user/group.