### PR TITLE
Make test feature names unique to the test

### DIFF
--- a/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/ClaimsPrincipals/ClaimsPrincipalSessionManagerTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/ClaimsPrincipals/ClaimsPrincipalSessionManagerTests.cs
@@ -9,6 +9,8 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.ClaimsPrincipa
 {
     public class ClaimsPrincipalSessionManagerTests
     {
+        private const string Pfx = TestConstants.Prefix;
+
         private ClaimsPrincipal CreateClaimsPrincipal(IEnumerable<string> featureFlagValues)
         {
             var claims = featureFlagValues
@@ -27,7 +29,7 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.ClaimsPrincipa
         [Fact]
         public async Task GetAsync_returns_true_for_featureName_with_no_prefix()
         {
-            const string featureName = "abc456-true";
+            var featureName = $"{Pfx}-875abc456-true";
             var principal = CreateClaimsPrincipal(new[]
             {
                 "someOtherFeatureTrue",
@@ -42,7 +44,7 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.ClaimsPrincipa
         [Fact]
         public async Task GetAsync_returns_false_for_featureName_with_exclamation_prefix()
         {
-            const string featureName = "Xyz123-false";
+            var featureName = $"{Pfx}-ZYX123-false";
             var principal = CreateClaimsPrincipal(new[]
             {
                 "ThisOtherUnrelatedFeature",
@@ -56,7 +58,7 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.ClaimsPrincipa
         [Fact]
         public async Task GetAsync_returns_null_for_featureName_not_set()
         {
-            const string featureName = "QRS175-null";
+            var featureName = $"{Pfx}-MQF3175-null";
             var principal = CreateClaimsPrincipal(new[]
             {
                 $"FeatureNot{featureName}",

--- a/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Sql/CachedSqlPerGuidSessionManagerSqlClientTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Sql/CachedSqlPerGuidSessionManagerSqlClientTests.cs
@@ -13,6 +13,7 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
     [Collection(nameof(SQLServerDatabaseCollection))]
     public class CachedSqlPerGuidSessionManagerSqlClientTests
     {
+        private const string Pfx = TestConstants.Prefix + "CSPGSMSCT";
         private readonly SqlServerDatabaseFixture _dbFixture;
         private Guid PrimaryUser => _userGuids.First();
         private readonly List<Guid> _userGuids = new List<Guid>();
@@ -53,14 +54,14 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         public async Task Return_null_for_nonexistent_key()
         {
             var sut = GetSutForUser(PrimaryUser);
-            var result = await sut.GetAsync("someRandomFeatureNonExistentName");
+            var result = await sut.GetAsync(Pfx+"someRandomFeatureNonExistentName");
             Assert.Null(result);
         }
 
         [Theory]
-        [InlineData(null, "Net48_A125a_FeatureSetToNull", null)]
-        [InlineData(false, "Net48_A125b_FeatureSetToFalse", false)]
-        [InlineData(true, "Net48_A125c_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_A125a_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_A125b_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_A125c_FeatureSetToTrue", true)]
         public async Task Return_expected_for_inserted_key_value(
             bool? expected,
             string featureName,
@@ -78,9 +79,9 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         }
 
         [Theory]
-        [InlineData(null, "Net48_A349x_FeatureSetToNull", null)]
-        [InlineData(false, "Net48_A349y_FeatureSetToFalse", false)]
-        [InlineData(true, "Net48_A349z_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_A349x_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_A349y_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_A349z_FeatureSetToTrue", true)]
         public async Task Return_expected_for_SetNullableValue(
             bool? expected,
             string featureName,
@@ -98,9 +99,9 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         }
 
         [Theory]
-        [InlineData(null, "Net48_A359jx_FeatureSetToNull", null)]
-        [InlineData(false, "Net48_A359ky_FeatureSetToFalse", false)]
-        [InlineData(true, "Net48_A359lz_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_A359jx_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_A359ky_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_A359lz_FeatureSetToTrue", true)]
         public async Task Return_expected_for_SetValue(
             bool? expected,
             string featureName,
@@ -121,7 +122,7 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         [Fact]
         public async Task Exercise_SetNullableValue()
         {
-            const string baseName = "Net48_C997_ExerciseRepeatedly";
+            const string baseName = Pfx+"_C997_ExerciseRepeatedly";
             const int maxIterations = 1500;
             for (var i = 0; i < maxIterations; i++)
             {
@@ -139,7 +140,7 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         [Fact]
         public async Task Exercise_SetValue()
         {
-            const string baseName = "Net48_C877_ExerciseRepeatedly";
+            const string baseName = Pfx+"_C877_ExerciseRepeatedly";
             const int maxIterations = 1500;
             for (var i = 0; i < maxIterations; i++)
             {

--- a/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Sql/CachedSqlSessionManagerSQLiteTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Sql/CachedSqlSessionManagerSQLiteTests.cs
@@ -10,6 +10,7 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
     [Collection(nameof(SQLiteDatabaseCollection))]
     public class CachedSqlSessionManagerSQLiteTests
     {
+        private const string Pfx = TestConstants.Prefix + "CSSMSQLiteCT";
         private readonly SQLiteDatabaseFixture _dbFixture;
 
         public CachedSqlSessionManagerSQLiteTests(SQLiteDatabaseFixture dbFixture)
@@ -30,14 +31,14 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         public async Task Return_null_for_nonexistent_key()
         {
             var sut = CreateSut();
-            var result = await sut.GetAsync("someRandomFeatureNonExistentName");
+            var result = await sut.GetAsync(Pfx+"someRandomFeatureNonExistentName");
             Assert.Null(result);
         }
 
         [Theory]
-        [InlineData(null, "Net48_A125a_FeatureSetToNull", null)]
-        [InlineData(false, "Net48_A125b_FeatureSetToFalse", false)]
-        [InlineData(true, "Net48_A125c_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_A125a_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_A125b_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_A125c_FeatureSetToTrue", true)]
         public async Task Return_expected_for_inserted_key_value(
             bool? expected,
             string featureName,
@@ -55,9 +56,9 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         }
 
         [Theory]
-        [InlineData(null, "Net48_A349x_FeatureSetToNull", null)]
-        [InlineData(false, "Net48_A349y_FeatureSetToFalse", false)]
-        [InlineData(true, "Net48_A349z_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_A349x_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_A349y_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_A349z_FeatureSetToTrue", true)]
         public async Task Return_expected_for_SetNullableValue(
             bool? expected,
             string featureName,
@@ -75,9 +76,9 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         }
 
         [Theory]
-        [InlineData(null, "Net48_A359jx_FeatureSetToNull", null)]
-        [InlineData(false, "Net48_A359ky_FeatureSetToFalse", false)]
-        [InlineData(true, "Net48_A359lz_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_A359jx_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_A359ky_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_A359lz_FeatureSetToTrue", true)]
         public async Task Return_expected_for_SetValue(
             bool? expected,
             string featureName,
@@ -99,7 +100,7 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         public async Task Exercise_SetNullableValue()
         {
             var sut = CreateSut();
-            const string baseName = "Net48_C997_ExerciseRepeatedly";
+            const string baseName = Pfx+"_C997_ExerciseRepeatedly";
             const int maxIterations = 1500;
             for (var i = 0; i < maxIterations; i++)
             {
@@ -116,7 +117,7 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         public async Task Exercise_SetValue()
         {
             var sut = CreateSut();
-            const string baseName = "Net48_C877_ExerciseRepeatedly";
+            const string baseName = Pfx+"_C877_ExerciseRepeatedly";
             const int maxIterations = 1500;
             for (var i = 0; i < maxIterations; i++)
             {

--- a/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Sql/CachedSqlSessionManagerSqlClientTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Sql/CachedSqlSessionManagerSqlClientTests.cs
@@ -10,6 +10,7 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
     [Collection(nameof(SQLServerDatabaseCollection))]
     public class CachedSqlSessionManagerSqlClient
     {
+        private const string Pfx = TestConstants.Prefix + "CSSMSCT";
         private readonly SqlServerDatabaseFixture _dbFixture;
 
         public CachedSqlSessionManagerSqlClient(SqlServerDatabaseFixture dbFixture)
@@ -30,14 +31,14 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         public async Task Return_null_for_nonexistent_key()
         {
             var sut = CreateSut();
-            var result = await sut.GetAsync("someRandomFeatureNonExistentName");
+            var result = await sut.GetAsync(Pfx+"someRandomFeatureNonExistentName");
             Assert.Null(result);
         }
 
         [Theory]
-        [InlineData(null, "Net48_A125a_FeatureSetToNull", null)]
-        [InlineData(false, "Net48_A125b_FeatureSetToFalse", false)]
-        [InlineData(true, "Net48_A125c_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_A125a_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_A125b_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_A125c_FeatureSetToTrue", true)]
         public async Task Return_expected_for_inserted_key_value(
             bool? expected,
             string featureName,
@@ -55,9 +56,9 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         }
 
         [Theory]
-        [InlineData(null, "Net48_A349x_FeatureSetToNull", null)]
-        [InlineData(false, "Net48_A349y_FeatureSetToFalse", false)]
-        [InlineData(true, "Net48_A349z_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_A349x_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_A349y_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_A349z_FeatureSetToTrue", true)]
         public async Task Return_expected_for_SetNullableValue(
             bool? expected,
             string featureName,
@@ -75,9 +76,9 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         }
 
         [Theory]
-        [InlineData(null, "Net48_A359jx_FeatureSetToNull", null)]
-        [InlineData(false, "Net48_A359ky_FeatureSetToFalse", false)]
-        [InlineData(true, "Net48_A359lz_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_A359jx_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_A359ky_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_A359lz_FeatureSetToTrue", true)]
         public async Task Return_expected_for_SetValue(
             bool? expected,
             string featureName,
@@ -99,7 +100,7 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         public async Task Exercise_SetNullableValue()
         {
             var sut = CreateSut();
-            const string baseName = "Net48_C997_ExerciseRepeatedly";
+            const string baseName = Pfx+"_C997_ExerciseRepeatedly";
             const int maxIterations = 1500;
             for (var i = 0; i < maxIterations; i++)
             {
@@ -116,7 +117,7 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         public async Task Exercise_SetValue()
         {
             var sut = CreateSut();
-            const string baseName = "Net48_C877_ExerciseRepeatedly";
+            const string baseName = Pfx+"_C877_ExerciseRepeatedly";
             const int maxIterations = 1500;
             for (var i = 0; i < maxIterations; i++)
             {

--- a/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Sql/SqlPerGuidSessionManagerSqlClientTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Sql/SqlPerGuidSessionManagerSqlClientTests.cs
@@ -13,6 +13,7 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
     [Collection(nameof(SQLServerDatabaseCollection))]
     public class SqlPerGuidSessionManagerSqlClientTests
     {
+        private const string Pfx = TestConstants.Prefix + "SGuidSMSQLCT";
         private readonly SqlServerDatabaseFixture _dbFixture;
         private Guid PrimaryUser => _userGuids.First();
         private readonly List<Guid> _userGuids = new List<Guid>();
@@ -53,14 +54,14 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         public async Task Return_null_for_nonexistent_key()
         {
             var sut = GetSutForUser(PrimaryUser);
-            var result = await sut.GetAsync("someRandomFeatureNonExistentName");
+            var result = await sut.GetAsync(Pfx+"someRandomFeatureNonExistentName");
             Assert.Null(result);
         }
 
         [Theory]
-        [InlineData(null, "Net48_M125a_FeatureSetToNull", null)]
-        [InlineData(false, "Net48_N125b_FeatureSetToFalse", false)]
-        [InlineData(true, "Net48_P125c_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_M125a_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_N125b_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_P125c_FeatureSetToTrue", true)]
         public async Task Return_expected_for_inserted_key_value(
             bool? expected,
             string featureName,
@@ -78,9 +79,9 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         }
 
         [Theory]
-        [InlineData(null, "Net48_J529x_FeatureSetToNull", null)]
-        [InlineData(false, "Net48_K329y_FeatureSetToFalse", false)]
-        [InlineData(true, "Net48_L729z_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_J529x_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_K329y_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_L729z_FeatureSetToTrue", true)]
         public async Task Return_expected_for_SetNullableValue(
             bool? expected,
             string featureName,
@@ -98,9 +99,9 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         }
 
         [Theory]
-        [InlineData(null, "Net48_D439jx_FeatureSetToNull", null)]
-        [InlineData(false, "Net48_E439ky_FeatureSetToFalse", false)]
-        [InlineData(true, "Net48_F439lz_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_D439jx_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_E439ky_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_F439lz_FeatureSetToTrue", true)]
         public async Task Return_expected_for_SetValue(
             bool? expected,
             string featureName,
@@ -121,7 +122,7 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         [Fact]
         public async Task Exercise_SetNullableValue()
         {
-            const string baseName = "Net48_B473_ExerciseRepeatedly";
+            const string baseName = Pfx+"_B473_ExerciseRepeatedly";
             const int maxIterations = 500;
             for (var i = 0; i < maxIterations; i++)
             {
@@ -139,7 +140,7 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         [Fact]
         public async Task Exercise_SetValue()
         {
-            const string baseName = "Net48_C985_ExerciseRepeatedly";
+            const string baseName = Pfx+"_C985_ExerciseRepeatedly";
             const int maxIterations = 500;
             for (var i = 0; i < maxIterations; i++)
             {

--- a/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Sql/SqlSessionManagerSQLiteTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Sql/SqlSessionManagerSQLiteTests.cs
@@ -10,6 +10,7 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
     [Collection(nameof(SQLiteDatabaseCollection))]
     public class SqlSessionManagerSQLiteTests
     {
+        private const string Pfx = TestConstants.Prefix + "SSMSQLiteCT";
         private readonly SQLiteDatabaseFixture _dbFixture;
 
         public SqlSessionManagerSQLiteTests(SQLiteDatabaseFixture dbFixture)
@@ -30,14 +31,14 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         public async Task Return_null_for_nonexistent_key()
         {
             var sut = CreateSut();
-            var result = await sut.GetAsync("someRandomFeatureNonExistentName");
+            var result = await sut.GetAsync(Pfx+"someRandomFeatureNonExistentName");
             Assert.Null(result);
         }
 
         [Theory]
-        [InlineData(null, "Net48_A125a_FeatureSetToNull", null)]
-        [InlineData(false, "Net48_A125b_FeatureSetToFalse", false)]
-        [InlineData(true, "Net48_A125c_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_A125a_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_A125b_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_A125c_FeatureSetToTrue", true)]
         public async Task Return_expected_for_inserted_key_value(
             bool? expected,
             string featureName,
@@ -55,9 +56,9 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         }
 
         [Theory]
-        [InlineData(null, "Net48_A129x_FeatureSetToNull", null)]
-        [InlineData(false, "Net48_A129y_FeatureSetToFalse", false)]
-        [InlineData(true, "Net48_A129z_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_A129x_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_A129y_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_A129z_FeatureSetToTrue", true)]
         public async Task Return_expected_for_SetNullableValue(
             bool? expected,
             string featureName,
@@ -75,9 +76,9 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         }
 
         [Theory]
-        [InlineData(null, "Net48_A139jx_FeatureSetToNull", null)]
-        [InlineData(false, "Net48_A139ky_FeatureSetToFalse", false)]
-        [InlineData(true, "Net48_A139lz_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_A139jx_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_A139ky_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_A139lz_FeatureSetToTrue", true)]
         public async Task Return_expected_for_SetValue(
             bool? expected,
             string featureName,
@@ -99,7 +100,7 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         public async Task Exercise_SetNullableValue()
         {
             var sut = CreateSut();
-            const string baseName = "Net48_A997_ExerciseRepeatedly";
+            const string baseName = Pfx+"_A997_ExerciseRepeatedly";
             const int maxIterations = 500;
             for (var i = 0; i < maxIterations; i++)
             {
@@ -116,7 +117,7 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         public async Task Exercise_SetValue()
         {
             var sut = CreateSut();
-            const string baseName = "Net48_A877_ExerciseRepeatedly";
+            const string baseName = Pfx+"_A877_ExerciseRepeatedly";
             const int maxIterations = 500;
             for (var i = 0; i < maxIterations; i++)
             {

--- a/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Sql/SqlSessionManagerSqlClientTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Sql/SqlSessionManagerSqlClientTests.cs
@@ -10,6 +10,7 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
     [Collection(nameof(SQLServerDatabaseCollection))]
     public class SqlSessionManagerSqlClientTests
     {
+        private const string Pfx = TestConstants.Prefix + "SSMSqlClientCT";
         private readonly SqlServerDatabaseFixture _dbFixture;
 
         public SqlSessionManagerSqlClientTests(SqlServerDatabaseFixture dbFixture)
@@ -30,14 +31,14 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         public async Task Return_null_for_nonexistent_key()
         {
             var sut = CreateSut();
-            var result = await sut.GetAsync("someRandomFeatureNonExistentName");
+            var result = await sut.GetAsync(Pfx+"someRandomFeatureNonExistentName");
             Assert.Null(result);
         }
 
         [Theory]
-        [InlineData(null, "Net48_A125a_FeatureSetToNull", null)]
-        [InlineData(false, "Net48_A125b_FeatureSetToFalse", false)]
-        [InlineData(true, "Net48_A125c_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_A125a_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_A125b_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_A125c_FeatureSetToTrue", true)]
         public async Task Return_expected_for_inserted_key_value(
             bool? expected,
             string featureName,
@@ -55,9 +56,9 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         }
 
         [Theory]
-        [InlineData(null, "Net48_A129x_FeatureSetToNull", null)]
-        [InlineData(false, "Net48_A129y_FeatureSetToFalse", false)]
-        [InlineData(true, "Net48_A129z_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_A129x_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_A129y_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_A129z_FeatureSetToTrue", true)]
         public async Task Return_expected_for_SetNullableValue(
             bool? expected,
             string featureName,
@@ -75,9 +76,9 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         }
 
         [Theory]
-        [InlineData(null, "Net48_A139jx_FeatureSetToNull", null)]
-        [InlineData(false, "Net48_A139ky_FeatureSetToFalse", false)]
-        [InlineData(true, "Net48_A139lz_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_A139jx_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_A139ky_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_A139lz_FeatureSetToTrue", true)]
         public async Task Return_expected_for_SetValue(
             bool? expected,
             string featureName,
@@ -99,7 +100,7 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         public async Task Exercise_SetNullableValue()
         {
             var sut = CreateSut();
-            const string baseName = "Net48_A997_ExerciseRepeatedly";
+            const string baseName = Pfx+"_A997_ExerciseRepeatedly";
             const int maxIterations = 500;
             for (var i = 0; i < maxIterations; i++)
             {
@@ -116,7 +117,7 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         public async Task Exercise_SetValue()
         {
             var sut = CreateSut();
-            const string baseName = "Net48_A877_ExerciseRepeatedly";
+            const string baseName = Pfx+"_A877_ExerciseRepeatedly";
             const int maxIterations = 500;
             for (var i = 0; i < maxIterations; i++)
             {

--- a/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Static/StaticAnswerSessionManagerTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Static/StaticAnswerSessionManagerTests.cs
@@ -8,9 +8,10 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Static
 {
     public class StaticAnswerSessionManagerTests
     {
-        private const string TrueFeature = nameof(TrueFeature);
-        private const string FalseFeature = nameof(FalseFeature);
-        private const string NullFeature = nameof(NullFeature);
+        private const string Pfx = TestConstants.Prefix;
+        private const string TrueFeature = Pfx + nameof(TrueFeature);
+        private const string FalseFeature = Pfx + nameof(FalseFeature);
+        private const string NullFeature = Pfx + nameof(NullFeature);
 
         private readonly StaticAnswerSessionManager _sut = new StaticAnswerSessionManager(
             new Dictionary<string, bool?>(StringComparer.OrdinalIgnoreCase)

--- a/tests/Lussatite.FeatureManagement.Net48.Tests/TestConstants.cs
+++ b/tests/Lussatite.FeatureManagement.Net48.Tests/TestConstants.cs
@@ -1,0 +1,9 @@
+namespace Lussatite.FeatureManagement.Net48.Tests
+{
+    public static class TestConstants
+    {
+        /// <summary>Used as the prefix for any test feature names.  Makes it easier to figure
+        /// out which test failed if the feature name key is unique.</summary>
+        public const string Prefix = "Net48";
+    }
+}

--- a/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/ClaimsPrincipals/ClaimsPrincipalSessionManagerTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/ClaimsPrincipals/ClaimsPrincipalSessionManagerTests.cs
@@ -9,6 +9,8 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.ClaimsPrincipal
 {
     public class ClaimsPrincipalSessionManagerTests
     {
+        private const string Pfx = TestConstants.Prefix;
+
         private ClaimsPrincipal CreateClaimsPrincipal(IEnumerable<string> featureFlagValues)
         {
             var claims = featureFlagValues
@@ -27,7 +29,7 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.ClaimsPrincipal
         [Fact]
         public async Task GetAsync_returns_true_for_featureName_with_no_prefix()
         {
-            const string featureName = "abc456-true";
+            var featureName = $"{Pfx}-pmq456-true";
             var principal = CreateClaimsPrincipal(new[]
             {
                 "someOtherFeatureTrue",
@@ -42,7 +44,7 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.ClaimsPrincipal
         [Fact]
         public async Task GetAsync_returns_false_for_featureName_with_exclamation_prefix()
         {
-            const string featureName = "Xyz123-false";
+            var featureName = $"{Pfx}-XYZ789-false";
             var principal = CreateClaimsPrincipal(new[]
             {
                 "ThisOtherUnrelatedFeature",
@@ -56,7 +58,7 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.ClaimsPrincipal
         [Fact]
         public async Task GetAsync_returns_null_for_featureName_not_set()
         {
-            const string featureName = "QRS175-null";
+            var featureName = $"{Pfx}QOJ-QRS175-null";
             var principal = CreateClaimsPrincipal(new[]
             {
                 $"FeatureNot{featureName}",

--- a/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Sql/CachedSqlPerGuidSessionManagerSqlClientTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Sql/CachedSqlPerGuidSessionManagerSqlClientTests.cs
@@ -13,6 +13,7 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
     [Collection(nameof(SQLServerDatabaseCollection))]
     public class CachedSqlPerGuidSessionManagerSqlClientTests
     {
+        private const string Pfx = TestConstants.Prefix + "CSPGSMSCT";
         private readonly SqlServerDatabaseFixture _dbFixture;
         private Guid PrimaryUser => _userGuids.First();
         private readonly List<Guid> _userGuids = new List<Guid>();
@@ -53,14 +54,14 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
         public async Task Return_null_for_nonexistent_key()
         {
             var sut = GetSutForUser(PrimaryUser);
-            var result = await sut.GetAsync("someRandomFeatureNonExistentName");
+            var result = await sut.GetAsync(Pfx+"someRandomFeatureNonExistentName");
             Assert.Null(result);
         }
 
         [Theory]
-        [InlineData(null, "Net48_A125a_FeatureSetToNull", null)]
-        [InlineData(false, "Net48_A125b_FeatureSetToFalse", false)]
-        [InlineData(true, "Net48_A125c_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_A125a_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_A125b_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_A125c_FeatureSetToTrue", true)]
         public async Task Return_expected_for_inserted_key_value(
             bool? expected,
             string featureName,
@@ -78,9 +79,9 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
         }
 
         [Theory]
-        [InlineData(null, "Net48_A349x_FeatureSetToNull", null)]
-        [InlineData(false, "Net48_A349y_FeatureSetToFalse", false)]
-        [InlineData(true, "Net48_A349z_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_A349x_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_A349y_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_A349z_FeatureSetToTrue", true)]
         public async Task Return_expected_for_SetNullableValue(
             bool? expected,
             string featureName,
@@ -98,9 +99,9 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
         }
 
         [Theory]
-        [InlineData(null, "Net48_A359jx_FeatureSetToNull", null)]
-        [InlineData(false, "Net48_A359ky_FeatureSetToFalse", false)]
-        [InlineData(true, "Net48_A359lz_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_A359jx_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_A359ky_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_A359lz_FeatureSetToTrue", true)]
         public async Task Return_expected_for_SetValue(
             bool? expected,
             string featureName,
@@ -121,7 +122,7 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
         [Fact]
         public async Task Exercise_SetNullableValue()
         {
-            const string baseName = "Net48_C997_ExerciseRepeatedly";
+            const string baseName = Pfx+"_C997_ExerciseRepeatedly";
             const int maxIterations = 1500;
             for (var i = 0; i < maxIterations; i++)
             {
@@ -139,7 +140,7 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
         [Fact]
         public async Task Exercise_SetValue()
         {
-            const string baseName = "Net48_C877_ExerciseRepeatedly";
+            const string baseName = Pfx+"_C877_ExerciseRepeatedly";
             const int maxIterations = 1500;
             for (var i = 0; i < maxIterations; i++)
             {

--- a/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Sql/CachedSqlSessionManagerSQLiteTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Sql/CachedSqlSessionManagerSQLiteTests.cs
@@ -10,6 +10,7 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
     [Collection(nameof(SQLiteDatabaseCollection))]
     public class CachedSqlSessionManagerSQLiteTests
     {
+        private const string Pfx = TestConstants.Prefix + "CSSMSQLiteCT";
         private readonly SQLiteDatabaseFixture _dbFixture;
 
         public CachedSqlSessionManagerSQLiteTests(SQLiteDatabaseFixture dbFixture)
@@ -30,15 +31,15 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
         public async Task Return_null_for_nonexistent_key()
         {
             var sut = CreateSut();
-            var result = await sut.GetAsync("someRandomFeatureNonExistentName");
+            var result = await sut.GetAsync(Pfx+"someRandomFeatureNonExistentName");
             Assert.Null(result);
         }
 
 
         [Theory]
-        [InlineData(null, "Net6_A125a_FeatureSetToNull", null)]
-        [InlineData(false, "Net6_A125b_FeatureSetToFalse", false)]
-        [InlineData(true, "Net6_A125c_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_A125a_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_A125b_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_A125c_FeatureSetToTrue", true)]
         public async Task Return_expected_for_inserted_key_value(
             bool? expected,
             string featureName,
@@ -56,9 +57,9 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
         }
 
         [Theory]
-        [InlineData(null, "Net6_A349x_FeatureSetToNull", null)]
-        [InlineData(false, "Net6_A349y_FeatureSetToFalse", false)]
-        [InlineData(true, "Net6_A349z_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_A349x_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_A349y_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_A349z_FeatureSetToTrue", true)]
         public async Task Return_expected_for_SetNullableValue(
             bool? expected,
             string featureName,
@@ -76,9 +77,9 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
         }
 
         [Theory]
-        [InlineData(null, "Net6_A359jx_FeatureSetToNull", null)]
-        [InlineData(false, "Net6_A359ky_FeatureSetToFalse", false)]
-        [InlineData(true, "Net6_A359lz_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_A359jx_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_A359ky_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_A359lz_FeatureSetToTrue", true)]
         public async Task Return_expected_for_SetValue(
             bool? expected,
             string featureName,
@@ -100,7 +101,7 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
         public async Task Exercise_SetNullableValue()
         {
             var sut = CreateSut();
-            const string baseName = "Net6_C997_ExerciseRepeatedly";
+            const string baseName = Pfx+"_C997_ExerciseRepeatedly";
             const int maxIterations = 1500;
             for (var i = 0; i < maxIterations; i++)
             {
@@ -117,7 +118,7 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
         public async Task Exercise_SetValue()
         {
             var sut = CreateSut();
-            const string baseName = "Net6_C877_ExerciseRepeatedly";
+            const string baseName = Pfx+"_C877_ExerciseRepeatedly";
             const int maxIterations = 1500;
             for (var i = 0; i < maxIterations; i++)
             {

--- a/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Sql/CachedSqlSessionManagerSqlClientTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Sql/CachedSqlSessionManagerSqlClientTests.cs
@@ -10,6 +10,7 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
     [Collection(nameof(SQLServerDatabaseCollection))]
     public class CachedSqlSessionManagerSqlClient
     {
+        private const string Pfx = TestConstants.Prefix + "CSSMSCT";
         private readonly SqlServerDatabaseFixture _dbFixture;
 
         public CachedSqlSessionManagerSqlClient(SqlServerDatabaseFixture dbFixture)
@@ -30,14 +31,14 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
         public async Task Return_null_for_nonexistent_key()
         {
             var sut = CreateSut();
-            var result = await sut.GetAsync("someRandomFeatureNonExistentName");
+            var result = await sut.GetAsync(Pfx+"someRandomFeatureNonExistentName");
             Assert.Null(result);
         }
 
         [Theory]
-        [InlineData(null, "Net48_A125a_FeatureSetToNull", null)]
-        [InlineData(false, "Net48_A125b_FeatureSetToFalse", false)]
-        [InlineData(true, "Net48_A125c_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_A125a_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_A125b_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_A125c_FeatureSetToTrue", true)]
         public async Task Return_expected_for_inserted_key_value(
             bool? expected,
             string featureName,
@@ -55,9 +56,9 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
         }
 
         [Theory]
-        [InlineData(null, "Net48_A349x_FeatureSetToNull", null)]
-        [InlineData(false, "Net48_A349y_FeatureSetToFalse", false)]
-        [InlineData(true, "Net48_A349z_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_A349x_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_A349y_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_A349z_FeatureSetToTrue", true)]
         public async Task Return_expected_for_SetNullableValue(
             bool? expected,
             string featureName,
@@ -75,9 +76,9 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
         }
 
         [Theory]
-        [InlineData(null, "Net48_A359jx_FeatureSetToNull", null)]
-        [InlineData(false, "Net48_A359ky_FeatureSetToFalse", false)]
-        [InlineData(true, "Net48_A359lz_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_A359jx_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_A359ky_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_A359lz_FeatureSetToTrue", true)]
         public async Task Return_expected_for_SetValue(
             bool? expected,
             string featureName,
@@ -99,7 +100,7 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
         public async Task Exercise_SetNullableValue()
         {
             var sut = CreateSut();
-            const string baseName = "Net48_C997_ExerciseRepeatedly";
+            const string baseName = Pfx+"_C997_ExerciseRepeatedly";
             const int maxIterations = 1500;
             for (var i = 0; i < maxIterations; i++)
             {
@@ -116,7 +117,7 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
         public async Task Exercise_SetValue()
         {
             var sut = CreateSut();
-            const string baseName = "Net48_C877_ExerciseRepeatedly";
+            const string baseName = Pfx+"_C877_ExerciseRepeatedly";
             const int maxIterations = 1500;
             for (var i = 0; i < maxIterations; i++)
             {

--- a/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Sql/SqlPerGuidSessionManagerSqlClientTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Sql/SqlPerGuidSessionManagerSqlClientTests.cs
@@ -13,6 +13,7 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
     [Collection(nameof(SQLServerDatabaseCollection))]
     public class SqlPerGuidSessionManagerSqlClientTests
     {
+        private const string Pfx = TestConstants.Prefix + "SGuidSMSQLCT";
         private readonly SqlServerDatabaseFixture _dbFixture;
         private Guid PrimaryUser => _userGuids.First();
         private readonly List<Guid> _userGuids = new List<Guid>();
@@ -53,14 +54,14 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
         public async Task Return_null_for_nonexistent_key()
         {
             var sut = GetSutForUser(PrimaryUser);
-            var result = await sut.GetAsync("someRandomFeatureNonExistentName");
+            var result = await sut.GetAsync(Pfx+"someRandomFeatureNonExistentName");
             Assert.Null(result);
         }
 
         [Theory]
-        [InlineData(null, "Net48_M125a_FeatureSetToNull", null)]
-        [InlineData(false, "Net48_N125b_FeatureSetToFalse", false)]
-        [InlineData(true, "Net48_P125c_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_M125a_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_N125b_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_P125c_FeatureSetToTrue", true)]
         public async Task Return_expected_for_inserted_key_value(
             bool? expected,
             string featureName,
@@ -78,9 +79,9 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
         }
 
         [Theory]
-        [InlineData(null, "Net48_J529x_FeatureSetToNull", null)]
-        [InlineData(false, "Net48_K329y_FeatureSetToFalse", false)]
-        [InlineData(true, "Net48_L729z_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_J529x_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_K329y_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_L729z_FeatureSetToTrue", true)]
         public async Task Return_expected_for_SetNullableValue(
             bool? expected,
             string featureName,
@@ -98,9 +99,9 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
         }
 
         [Theory]
-        [InlineData(null, "Net48_D439jx_FeatureSetToNull", null)]
-        [InlineData(false, "Net48_E439ky_FeatureSetToFalse", false)]
-        [InlineData(true, "Net48_F439lz_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_D439jx_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_E439ky_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_F439lz_FeatureSetToTrue", true)]
         public async Task Return_expected_for_SetValue(
             bool? expected,
             string featureName,
@@ -121,7 +122,7 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
         [Fact]
         public async Task Exercise_SetNullableValue()
         {
-            const string baseName = "Net48_B473_ExerciseRepeatedly";
+            const string baseName = Pfx+"_B473_ExerciseRepeatedly";
             const int maxIterations = 500;
             for (var i = 0; i < maxIterations; i++)
             {
@@ -139,7 +140,7 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
         [Fact]
         public async Task Exercise_SetValue()
         {
-            const string baseName = "Net48_C985_ExerciseRepeatedly";
+            const string baseName = Pfx+"_C985_ExerciseRepeatedly";
             const int maxIterations = 500;
             for (var i = 0; i < maxIterations; i++)
             {

--- a/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Sql/SqlSessionManagerSQLiteTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Sql/SqlSessionManagerSQLiteTests.cs
@@ -10,6 +10,7 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
     [Collection(nameof(SQLiteDatabaseCollection))]
     public class SqlSessionManagerSQLiteTests
     {
+        private const string Pfx = TestConstants.Prefix + "SSMSQLiteCT";
         private readonly SQLiteDatabaseFixture _dbFixture;
 
         public SqlSessionManagerSQLiteTests(SQLiteDatabaseFixture dbFixture)
@@ -30,14 +31,14 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
         public async Task Return_null_for_nonexistent_key()
         {
             var sut = CreateSut();
-            var result = await sut.GetAsync("someRandomFeatureNonExistentName");
+            var result = await sut.GetAsync(Pfx+"someRandomFeatureNonExistentName");
             Assert.Null(result);
         }
 
         [Theory]
-        [InlineData(null, "Net6_A125a_FeatureSetToNull", null)]
-        [InlineData(false, "Net6_A125b_FeatureSetToFalse", false)]
-        [InlineData(true, "Net6_A125c_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_A125a_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_A125b_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_A125c_FeatureSetToTrue", true)]
         public async Task Return_expected_for_inserted_key_value(
             bool? expected,
             string featureName,
@@ -55,9 +56,9 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
         }
 
         [Theory]
-        [InlineData(null, "Net6_A129x_FeatureSetToNull", null)]
-        [InlineData(false, "Net6_A129y_FeatureSetToFalse", false)]
-        [InlineData(true, "Net6_A129z_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_A129x_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_A129y_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_A129z_FeatureSetToTrue", true)]
         public async Task Return_expected_for_SetNullableValue(
             bool? expected,
             string featureName,
@@ -75,9 +76,9 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
         }
 
         [Theory]
-        [InlineData(null, "Net6_A139jx_FeatureSetToNull", null)]
-        [InlineData(false, "Net6_A139ky_FeatureSetToFalse", false)]
-        [InlineData(true, "Net6_A139lz_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_A139jx_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_A139ky_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_A139lz_FeatureSetToTrue", true)]
         public async Task Return_expected_for_SetValue(
             bool? expected,
             string featureName,
@@ -99,7 +100,7 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
         public async Task Exercise_SetNullableValue()
         {
             var sut = CreateSut();
-            const string baseName = "Net6_A997_ExerciseRepeatedly";
+            const string baseName = Pfx+"_A997_ExerciseRepeatedly";
             const int maxIterations = 500;
             for (var i = 0; i < maxIterations; i++)
             {
@@ -116,7 +117,7 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
         public async Task Exercise_SetValue()
         {
             var sut = CreateSut();
-            const string baseName = "Net6_A877_ExerciseRepeatedly";
+            const string baseName = Pfx+"_A877_ExerciseRepeatedly";
             const int maxIterations = 500;
             for (var i = 0; i < maxIterations; i++)
             {

--- a/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Sql/SqlSessionManagerSqlClientTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Sql/SqlSessionManagerSqlClientTests.cs
@@ -10,6 +10,7 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
     [Collection(nameof(SQLServerDatabaseCollection))]
     public class SqlSessionManagerSqlClientTests
     {
+        private const string Pfx = TestConstants.Prefix + "SSMSqlClientCT";
         private readonly SqlServerDatabaseFixture _dbFixture;
 
         public SqlSessionManagerSqlClientTests(SqlServerDatabaseFixture dbFixture)
@@ -30,14 +31,14 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
         public async Task Return_null_for_nonexistent_key()
         {
             var sut = CreateSut();
-            var result = await sut.GetAsync("someRandomFeatureNonExistentName");
+            var result = await sut.GetAsync(Pfx+"someRandomFeatureNonExistentName");
             Assert.Null(result);
         }
 
         [Theory]
-        [InlineData(null, "Net48_A125a_FeatureSetToNull", null)]
-        [InlineData(false, "Net48_A125b_FeatureSetToFalse", false)]
-        [InlineData(true, "Net48_A125c_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_A125a_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_A125b_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_A125c_FeatureSetToTrue", true)]
         public async Task Return_expected_for_inserted_key_value(
             bool? expected,
             string featureName,
@@ -55,9 +56,9 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
         }
 
         [Theory]
-        [InlineData(null, "Net48_A129x_FeatureSetToNull", null)]
-        [InlineData(false, "Net48_A129y_FeatureSetToFalse", false)]
-        [InlineData(true, "Net48_A129z_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_A129x_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_A129y_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_A129z_FeatureSetToTrue", true)]
         public async Task Return_expected_for_SetNullableValue(
             bool? expected,
             string featureName,
@@ -75,9 +76,9 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
         }
 
         [Theory]
-        [InlineData(null, "Net48_A139jx_FeatureSetToNull", null)]
-        [InlineData(false, "Net48_A139ky_FeatureSetToFalse", false)]
-        [InlineData(true, "Net48_A139lz_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_A139jx_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_A139ky_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_A139lz_FeatureSetToTrue", true)]
         public async Task Return_expected_for_SetValue(
             bool? expected,
             string featureName,
@@ -99,7 +100,7 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
         public async Task Exercise_SetNullableValue()
         {
             var sut = CreateSut();
-            const string baseName = "Net48_A997_ExerciseRepeatedly";
+            const string baseName = Pfx+"_A997_ExerciseRepeatedly";
             const int maxIterations = 500;
             for (var i = 0; i < maxIterations; i++)
             {
@@ -116,7 +117,7 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
         public async Task Exercise_SetValue()
         {
             var sut = CreateSut();
-            const string baseName = "Net48_A877_ExerciseRepeatedly";
+            const string baseName = Pfx+"_A877_ExerciseRepeatedly";
             const int maxIterations = 500;
             for (var i = 0; i < maxIterations; i++)
             {

--- a/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Static/StaticAnswerSessionManagerTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Static/StaticAnswerSessionManagerTests.cs
@@ -8,9 +8,10 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Static;
 
 public class StaticAnswerSessionManagerTests
 {
-    private const string TrueFeature = nameof(TrueFeature);
-    private const string FalseFeature = nameof(FalseFeature);
-    private const string NullFeature = nameof(NullFeature);
+    private const string Pfx = TestConstants.Prefix;
+    private const string TrueFeature = Pfx + nameof(TrueFeature);
+    private const string FalseFeature = Pfx + nameof(FalseFeature);
+    private const string NullFeature = Pfx + nameof(NullFeature);
 
     private readonly StaticAnswerSessionManager _sut = new StaticAnswerSessionManager(
         new Dictionary<string, bool?>(StringComparer.OrdinalIgnoreCase)

--- a/tests/Lussatite.FeatureManagement.Net6.Tests/TestConstants.cs
+++ b/tests/Lussatite.FeatureManagement.Net6.Tests/TestConstants.cs
@@ -1,0 +1,9 @@
+namespace Lussatite.FeatureManagement.Net6.Tests
+{
+    public static class TestConstants
+    {
+        /// <summary>Used as the prefix for any test feature names.  Makes it easier to figure
+        /// out which test failed if the feature name key is unique.</summary>
+        public const string Prefix = "Net6";
+    }
+}

--- a/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/ClaimsPrincipals/ClaimsPrincipalSessionManagerTests.cs
+++ b/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/ClaimsPrincipals/ClaimsPrincipalSessionManagerTests.cs
@@ -9,6 +9,8 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.ClaimsPrin
 {
     public class ClaimsPrincipalSessionManagerTests
     {
+        private const string Pfx = TestConstants.Prefix;
+
         private ClaimsPrincipal CreateClaimsPrincipal(IEnumerable<string> featureFlagValues)
         {
             var claims = featureFlagValues
@@ -27,7 +29,7 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.ClaimsPrin
         [Fact]
         public async Task GetAsync_returns_true_for_featureName_with_no_prefix()
         {
-            const string featureName = "abc456-true";
+            var featureName = $"{Pfx}-AXJ456-true";
             var principal = CreateClaimsPrincipal(new[]
             {
                 "someOtherFeatureTrue",
@@ -42,7 +44,7 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.ClaimsPrin
         [Fact]
         public async Task GetAsync_returns_false_for_featureName_with_exclamation_prefix()
         {
-            const string featureName = "Xyz123-false";
+            var featureName = $"{Pfx}-Xyz123-false";
             var principal = CreateClaimsPrincipal(new[]
             {
                 "ThisOtherUnrelatedFeature",
@@ -56,7 +58,7 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.ClaimsPrin
         [Fact]
         public async Task GetAsync_returns_null_for_featureName_not_set()
         {
-            const string featureName = "QRS175-null";
+            var featureName = $"{Pfx}-RS232-null";
             var principal = CreateClaimsPrincipal(new[]
             {
                 $"FeatureNot{featureName}",

--- a/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/Sql/CachedSqlPerGuidSessionManagerSqlClientTests.cs
+++ b/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/Sql/CachedSqlPerGuidSessionManagerSqlClientTests.cs
@@ -13,6 +13,7 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
     [Collection(nameof(SQLServerDatabaseCollection))]
     public class CachedSqlPerGuidSessionManagerSqlClientTests
     {
+        private const string Pfx = TestConstants.Prefix + "CSPGSMSCT";
         private readonly SqlServerDatabaseFixture _dbFixture;
         private Guid PrimaryUser => _userGuids.First();
         private readonly List<Guid> _userGuids = new List<Guid>();
@@ -53,14 +54,14 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
         public async Task Return_null_for_nonexistent_key()
         {
             var sut = GetSutForUser(PrimaryUser);
-            var result = await sut.GetAsync("someRandomFeatureNonExistentName");
+            var result = await sut.GetAsync(Pfx+"someRandomFeatureNonExistentName");
             Assert.Null(result);
         }
 
         [Theory]
-        [InlineData(null, "Net48_A125a_FeatureSetToNull", null)]
-        [InlineData(false, "Net48_A125b_FeatureSetToFalse", false)]
-        [InlineData(true, "Net48_A125c_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_A125a_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_A125b_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_A125c_FeatureSetToTrue", true)]
         public async Task Return_expected_for_inserted_key_value(
             bool? expected,
             string featureName,
@@ -78,9 +79,9 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
         }
 
         [Theory]
-        [InlineData(null, "Net48_A349x_FeatureSetToNull", null)]
-        [InlineData(false, "Net48_A349y_FeatureSetToFalse", false)]
-        [InlineData(true, "Net48_A349z_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_A349x_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_A349y_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_A349z_FeatureSetToTrue", true)]
         public async Task Return_expected_for_SetNullableValue(
             bool? expected,
             string featureName,
@@ -98,9 +99,9 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
         }
 
         [Theory]
-        [InlineData(null, "Net48_A359jx_FeatureSetToNull", null)]
-        [InlineData(false, "Net48_A359ky_FeatureSetToFalse", false)]
-        [InlineData(true, "Net48_A359lz_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_A359jx_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_A359ky_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_A359lz_FeatureSetToTrue", true)]
         public async Task Return_expected_for_SetValue(
             bool? expected,
             string featureName,
@@ -121,7 +122,7 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
         [Fact]
         public async Task Exercise_SetNullableValue()
         {
-            const string baseName = "Net48_C997_ExerciseRepeatedly";
+            const string baseName = Pfx+"_C997_ExerciseRepeatedly";
             const int maxIterations = 1500;
             for (var i = 0; i < maxIterations; i++)
             {
@@ -139,7 +140,7 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
         [Fact]
         public async Task Exercise_SetValue()
         {
-            const string baseName = "Net48_C877_ExerciseRepeatedly";
+            const string baseName = Pfx+"_C877_ExerciseRepeatedly";
             const int maxIterations = 1500;
             for (var i = 0; i < maxIterations; i++)
             {

--- a/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/Sql/CachedSqlSessionManagerSQLiteTests.cs
+++ b/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/Sql/CachedSqlSessionManagerSQLiteTests.cs
@@ -10,6 +10,7 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
     [Collection(nameof(SQLiteDatabaseCollection))]
     public class CachedSqlSessionManagerSQLiteTests
     {
+        private const string Pfx = TestConstants.Prefix + "CSSMSQLiteCT";
         private readonly SQLiteDatabaseFixture _dbFixture;
 
         public CachedSqlSessionManagerSQLiteTests(SQLiteDatabaseFixture dbFixture)
@@ -30,15 +31,15 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
         public async Task Return_null_for_nonexistent_key()
         {
             var sut = CreateSut();
-            var result = await sut.GetAsync("someRandomFeatureNonExistentName");
+            var result = await sut.GetAsync(Pfx+"someRandomFeatureNonExistentName");
             Assert.Null(result);
         }
 
 
         [Theory]
-        [InlineData(null, "NetCore31_A125a_FeatureSetToNull", null)]
-        [InlineData(false, "NetCore31_A125b_FeatureSetToFalse", false)]
-        [InlineData(true, "NetCore31_A125c_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_A125a_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_A125b_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_A125c_FeatureSetToTrue", true)]
         public async Task Return_expected_for_inserted_key_value(
             bool? expected,
             string featureName,
@@ -56,9 +57,9 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
         }
 
         [Theory]
-        [InlineData(null, "NetCore31_A349x_FeatureSetToNull", null)]
-        [InlineData(false, "NetCore31_A349y_FeatureSetToFalse", false)]
-        [InlineData(true, "NetCore31_A349z_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_A349x_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_A349y_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_A349z_FeatureSetToTrue", true)]
         public async Task Return_expected_for_SetNullableValue(
             bool? expected,
             string featureName,
@@ -76,9 +77,9 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
         }
 
         [Theory]
-        [InlineData(null, "NetCore31_A359jx_FeatureSetToNull", null)]
-        [InlineData(false, "NetCore31_A359ky_FeatureSetToFalse", false)]
-        [InlineData(true, "NetCore31_A359lz_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_A359jx_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_A359ky_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_A359lz_FeatureSetToTrue", true)]
         public async Task Return_expected_for_SetValue(
             bool? expected,
             string featureName,
@@ -100,7 +101,7 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
         public async Task Exercise_SetNullableValue()
         {
             var sut = CreateSut();
-            const string baseName = "NetCore31_C997_ExerciseRepeatedly";
+            const string baseName = Pfx+"_C997_ExerciseRepeatedly";
             const int maxIterations = 1500;
             for (var i = 0; i < maxIterations; i++)
             {
@@ -117,7 +118,7 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
         public async Task Exercise_SetValue()
         {
             var sut = CreateSut();
-            const string baseName = "NetCore31_C877_ExerciseRepeatedly";
+            const string baseName = Pfx+"_C877_ExerciseRepeatedly";
             const int maxIterations = 1500;
             for (var i = 0; i < maxIterations; i++)
             {

--- a/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/Sql/CachedSqlSessionManagerSqlClientTests.cs
+++ b/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/Sql/CachedSqlSessionManagerSqlClientTests.cs
@@ -10,6 +10,7 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
     [Collection(nameof(SQLServerDatabaseCollection))]
     public class CachedSqlSessionManagerSqlClient
     {
+        private const string Pfx = TestConstants.Prefix + "CSSMSCT";
         private readonly SqlServerDatabaseFixture _dbFixture;
 
         public CachedSqlSessionManagerSqlClient(SqlServerDatabaseFixture dbFixture)
@@ -30,14 +31,14 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
         public async Task Return_null_for_nonexistent_key()
         {
             var sut = CreateSut();
-            var result = await sut.GetAsync("someRandomFeatureNonExistentName");
+            var result = await sut.GetAsync(Pfx+"someRandomFeatureNonExistentName");
             Assert.Null(result);
         }
 
         [Theory]
-        [InlineData(null, "Net48_A125a_FeatureSetToNull", null)]
-        [InlineData(false, "Net48_A125b_FeatureSetToFalse", false)]
-        [InlineData(true, "Net48_A125c_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"A125a_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"A125b_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_A125c_FeatureSetToTrue", true)]
         public async Task Return_expected_for_inserted_key_value(
             bool? expected,
             string featureName,
@@ -55,9 +56,9 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
         }
 
         [Theory]
-        [InlineData(null, "Net48_A349x_FeatureSetToNull", null)]
-        [InlineData(false, "Net48_A349y_FeatureSetToFalse", false)]
-        [InlineData(true, "Net48_A349z_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_A349x_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_A349y_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_A349z_FeatureSetToTrue", true)]
         public async Task Return_expected_for_SetNullableValue(
             bool? expected,
             string featureName,
@@ -75,9 +76,9 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
         }
 
         [Theory]
-        [InlineData(null, "Net48_A359jx_FeatureSetToNull", null)]
-        [InlineData(false, "Net48_A359ky_FeatureSetToFalse", false)]
-        [InlineData(true, "Net48_A359lz_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_A359jx_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_A359ky_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_A359lz_FeatureSetToTrue", true)]
         public async Task Return_expected_for_SetValue(
             bool? expected,
             string featureName,
@@ -99,7 +100,7 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
         public async Task Exercise_SetNullableValue()
         {
             var sut = CreateSut();
-            const string baseName = "Net48_C997_ExerciseRepeatedly";
+            const string baseName = Pfx+"_C997_ExerciseRepeatedly";
             const int maxIterations = 1500;
             for (var i = 0; i < maxIterations; i++)
             {
@@ -116,7 +117,7 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
         public async Task Exercise_SetValue()
         {
             var sut = CreateSut();
-            const string baseName = "Net48_C877_ExerciseRepeatedly";
+            const string baseName = Pfx+"_C877_ExerciseRepeatedly";
             const int maxIterations = 1500;
             for (var i = 0; i < maxIterations; i++)
             {

--- a/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/Sql/SqlPerGuidSessionManagerSqlClientTests.cs
+++ b/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/Sql/SqlPerGuidSessionManagerSqlClientTests.cs
@@ -13,6 +13,7 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
     [Collection(nameof(SQLServerDatabaseCollection))]
     public class SqlPerGuidSessionManagerSqlClientTests
     {
+        private const string Pfx = TestConstants.Prefix + "SGuidSMSQLCT";
         private readonly SqlServerDatabaseFixture _dbFixture;
         private Guid PrimaryUser => _userGuids.First();
         private readonly List<Guid> _userGuids = new List<Guid>();
@@ -53,14 +54,14 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
         public async Task Return_null_for_nonexistent_key()
         {
             var sut = GetSutForUser(PrimaryUser);
-            var result = await sut.GetAsync("someRandomFeatureNonExistentName");
+            var result = await sut.GetAsync(Pfx+"someRandomFeatureNonExistentName");
             Assert.Null(result);
         }
 
         [Theory]
-        [InlineData(null, "Net48_M125a_FeatureSetToNull", null)]
-        [InlineData(false, "Net48_N125b_FeatureSetToFalse", false)]
-        [InlineData(true, "Net48_P125c_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_M125a_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_N125b_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_P125c_FeatureSetToTrue", true)]
         public async Task Return_expected_for_inserted_key_value(
             bool? expected,
             string featureName,
@@ -78,9 +79,9 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
         }
 
         [Theory]
-        [InlineData(null, "Net48_J529x_FeatureSetToNull", null)]
-        [InlineData(false, "Net48_K329y_FeatureSetToFalse", false)]
-        [InlineData(true, "Net48_L729z_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_J529x_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_K329y_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_L729z_FeatureSetToTrue", true)]
         public async Task Return_expected_for_SetNullableValue(
             bool? expected,
             string featureName,
@@ -98,9 +99,9 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
         }
 
         [Theory]
-        [InlineData(null, "Net48_D439jx_FeatureSetToNull", null)]
-        [InlineData(false, "Net48_E439ky_FeatureSetToFalse", false)]
-        [InlineData(true, "Net48_F439lz_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_D439jx_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_E439ky_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_F439lz_FeatureSetToTrue", true)]
         public async Task Return_expected_for_SetValue(
             bool? expected,
             string featureName,
@@ -121,7 +122,7 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
         [Fact]
         public async Task Exercise_SetNullableValue()
         {
-            const string baseName = "Net48_B473_ExerciseRepeatedly";
+            const string baseName = Pfx+"_B473_ExerciseRepeatedly";
             const int maxIterations = 500;
             for (var i = 0; i < maxIterations; i++)
             {
@@ -139,7 +140,7 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
         [Fact]
         public async Task Exercise_SetValue()
         {
-            const string baseName = "Net48_C985_ExerciseRepeatedly";
+            const string baseName = Pfx+"_C985_ExerciseRepeatedly";
             const int maxIterations = 500;
             for (var i = 0; i < maxIterations; i++)
             {

--- a/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/Sql/SqlSessionManagerSQLiteTests.cs
+++ b/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/Sql/SqlSessionManagerSQLiteTests.cs
@@ -10,6 +10,7 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
     [Collection(nameof(SQLiteDatabaseCollection))]
     public class SqlSessionManagerSQLiteTests
     {
+        private const string Pfx = TestConstants.Prefix + "SSMSQLiteCT";
         private readonly SQLiteDatabaseFixture _dbFixture;
 
         public SqlSessionManagerSQLiteTests(SQLiteDatabaseFixture dbFixture)
@@ -30,14 +31,14 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
         public async Task Return_null_for_nonexistent_key()
         {
             var sut = CreateSut();
-            var result = await sut.GetAsync("someRandomFeatureNonExistentName");
+            var result = await sut.GetAsync($"{Pfx}someRandomFeatureNonExistentName");
             Assert.Null(result);
         }
 
         [Theory]
-        [InlineData(null, "NetCore31_A125a_FeatureSetToNull", null)]
-        [InlineData(false, "NetCore31_A125b_FeatureSetToFalse", false)]
-        [InlineData(true, "NetCore31_A125c_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_A125a_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_A125b_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_A125c_FeatureSetToTrue", true)]
         public async Task Return_expected_for_inserted_key_value(
             bool? expected,
             string featureName,
@@ -55,9 +56,9 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
         }
 
         [Theory]
-        [InlineData(null, "NetCore31_A129x_FeatureSetToNull", null)]
-        [InlineData(false, "NetCore31_A129y_FeatureSetToFalse", false)]
-        [InlineData(true, "NetCore31_A129z_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_A129x_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_A129y_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_A129z_FeatureSetToTrue", true)]
         public async Task Return_expected_for_SetNullableValue(
             bool? expected,
             string featureName,
@@ -75,9 +76,9 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
         }
 
         [Theory]
-        [InlineData(null, "NetCore31_A139jx_FeatureSetToNull", null)]
-        [InlineData(false, "NetCore31_A139ky_FeatureSetToFalse", false)]
-        [InlineData(true, "NetCore31_A139lz_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_A139jx_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_A139ky_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_A139lz_FeatureSetToTrue", true)]
         public async Task Return_expected_for_SetValue(
             bool? expected,
             string featureName,
@@ -99,7 +100,7 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
         public async Task Exercise_SetNullableValue()
         {
             var sut = CreateSut();
-            const string baseName = "NetCore31_A997_ExerciseRepeatedly";
+            const string baseName = Pfx+"_A997_ExerciseRepeatedly";
             const int maxIterations = 500;
             for (var i = 0; i < maxIterations; i++)
             {
@@ -116,7 +117,7 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
         public async Task Exercise_SetValue()
         {
             var sut = CreateSut();
-            const string baseName = "NetCore31_A877_ExerciseRepeatedly";
+            const string baseName = Pfx+"_A877_ExerciseRepeatedly";
             const int maxIterations = 500;
             for (var i = 0; i < maxIterations; i++)
             {

--- a/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/Sql/SqlSessionManagerSqlClientTests.cs
+++ b/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/Sql/SqlSessionManagerSqlClientTests.cs
@@ -10,6 +10,7 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
     [Collection(nameof(SQLServerDatabaseCollection))]
     public class SqlSessionManagerSqlClientTests
     {
+        private const string Pfx = TestConstants.Prefix + "SSMSqlClientCT";
         private readonly SqlServerDatabaseFixture _dbFixture;
 
         public SqlSessionManagerSqlClientTests(SqlServerDatabaseFixture dbFixture)
@@ -30,14 +31,14 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
         public async Task Return_null_for_nonexistent_key()
         {
             var sut = CreateSut();
-            var result = await sut.GetAsync("someRandomFeatureNonExistentName");
+            var result = await sut.GetAsync(Pfx+"someRandomFeatureNonExistentName");
             Assert.Null(result);
         }
 
         [Theory]
-        [InlineData(null, "Net48_A125a_FeatureSetToNull", null)]
-        [InlineData(false, "Net48_A125b_FeatureSetToFalse", false)]
-        [InlineData(true, "Net48_A125c_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_A125a_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_A125b_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_A125c_FeatureSetToTrue", true)]
         public async Task Return_expected_for_inserted_key_value(
             bool? expected,
             string featureName,
@@ -55,9 +56,9 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
         }
 
         [Theory]
-        [InlineData(null, "Net48_A129x_FeatureSetToNull", null)]
-        [InlineData(false, "Net48_A129y_FeatureSetToFalse", false)]
-        [InlineData(true, "Net48_A129z_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_A129x_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_A129y_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_A129z_FeatureSetToTrue", true)]
         public async Task Return_expected_for_SetNullableValue(
             bool? expected,
             string featureName,
@@ -75,9 +76,9 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
         }
 
         [Theory]
-        [InlineData(null, "Net48_A139jx_FeatureSetToNull", null)]
-        [InlineData(false, "Net48_A139ky_FeatureSetToFalse", false)]
-        [InlineData(true, "Net48_A139lz_FeatureSetToTrue", true)]
+        [InlineData(null, Pfx+"_A139jx_FeatureSetToNull", null)]
+        [InlineData(false, Pfx+"_A139ky_FeatureSetToFalse", false)]
+        [InlineData(true, Pfx+"_A139lz_FeatureSetToTrue", true)]
         public async Task Return_expected_for_SetValue(
             bool? expected,
             string featureName,
@@ -99,7 +100,7 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
         public async Task Exercise_SetNullableValue()
         {
             var sut = CreateSut();
-            const string baseName = "Net48_A997_ExerciseRepeatedly";
+            const string baseName = Pfx+"_A997_ExerciseRepeatedly";
             const int maxIterations = 500;
             for (var i = 0; i < maxIterations; i++)
             {
@@ -116,7 +117,7 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
         public async Task Exercise_SetValue()
         {
             var sut = CreateSut();
-            const string baseName = "Net48_A877_ExerciseRepeatedly";
+            const string baseName = Pfx+"_A877_ExerciseRepeatedly";
             const int maxIterations = 500;
             for (var i = 0; i < maxIterations; i++)
             {

--- a/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/Static/StaticAnswerSessionManagerTests.cs
+++ b/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/Static/StaticAnswerSessionManagerTests.cs
@@ -8,9 +8,10 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Static
 {
     public class StaticAnswerSessionManagerTests
     {
-        private const string TrueFeature = nameof(TrueFeature);
-        private const string FalseFeature = nameof(FalseFeature);
-        private const string NullFeature = nameof(NullFeature);
+        private const string Pfx = TestConstants.Prefix;
+        private const string TrueFeature = Pfx + nameof(TrueFeature);
+        private const string FalseFeature = Pfx + nameof(FalseFeature);
+        private const string NullFeature = Pfx + nameof(NullFeature);
 
         private readonly StaticAnswerSessionManager _sut = new StaticAnswerSessionManager(
             new Dictionary<string, bool?>(StringComparer.OrdinalIgnoreCase)

--- a/tests/Lussatite.FeatureManagement.NetCore31.Tests/TestConstants.cs
+++ b/tests/Lussatite.FeatureManagement.NetCore31.Tests/TestConstants.cs
@@ -1,0 +1,9 @@
+namespace Lussatite.FeatureManagement.NetCore31.Tests
+{
+    public static class TestConstants
+    {
+        /// <summary>Used as the prefix for any test feature names.  Makes it easier to figure
+        /// out which test failed if the feature name key is unique.</summary>
+        public const string Prefix = "NetCore31";
+    }
+}


### PR DESCRIPTION
As a general guideline, it is useful to have unique strings for any feature
names in tests.  Not only to avoid tests stepping on each other if the
context happens to be shared, but also to make it easier to track down
which test failed.

(I also keep forgetting to change the prefix when copying code around.)