### PR TITLE
Use global application's IAppCache if possible

### DIFF
--- a/src/Lussatite.FeatureManagement.SessionManagers.SqlClient/SQLServerPerGuidSessionManagerSettings.cs
+++ b/src/Lussatite.FeatureManagement.SessionManagers.SqlClient/SQLServerPerGuidSessionManagerSettings.cs
@@ -18,6 +18,14 @@ namespace Lussatite.FeatureManagement.SessionManagers.SqlClient
 
         protected override string DefaultTableName => "FeatureManagementByGuid";
 
+        /// <summary>Calculate the cache key to be used when storing data in an application's global cache.
+        /// By including the schema/table name, we generate a unique key for the feature name; even if
+        /// there are multiple feature value tables in use.  This also adds in the GUID as part of
+        /// the key so that users can have their feature values stored in the shared application cache.
+        /// </summary>
+        public override string CacheKey(string featureName) =>
+            $"{CacheKeyPrefix}-{FeatureSchemaName}-{FeatureTableName}-{UserGuid:N}-{featureName}";
+
         private const string DefaultUserGuidColumn = "UserGuid";
         private string _featureUserGuidColumn = DefaultUserGuidColumn;
 

--- a/src/Lussatite.FeatureManagement.SessionManagers/Sql/SqlSessionManagerSettings.cs
+++ b/src/Lussatite.FeatureManagement.SessionManagers/Sql/SqlSessionManagerSettings.cs
@@ -2,6 +2,7 @@ using System;
 using System.Data.Common;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using LazyCache;
 
 // ReSharper disable once CheckNamespace
 namespace Lussatite.FeatureManagement.SessionManagers
@@ -32,6 +33,15 @@ namespace Lussatite.FeatureManagement.SessionManagers
         public virtual bool IsValidSchemaName(string schemaName) => _restrictiveRegex.IsMatch(schemaName);
         public virtual bool IsValidTableName(string tableName) => _restrictiveRegex.IsMatch(tableName);
         public virtual bool IsValidColumnName(string columnName) => _restrictiveRegex.IsMatch(columnName);
+
+        protected virtual string CacheKeyPrefix => $"Lussatite.FeatureManagement-{nameof(SqlSessionManagerSettings)}";
+
+        /// <summary>Calculate the cache key to be used when storing data in an application's global
+        /// <see cref="IAppCache"/>.  By including the schema/table name, we generate a unique
+        /// key for the feature name; even if there are multiple feature value tables in use.
+        /// </summary>
+        public virtual string CacheKey(string featureName) =>
+            $"{CacheKeyPrefix}-{FeatureSchemaName}-{FeatureTableName}-{featureName}";
 
         /// <summary>The database schema name which holds the feature values table.  Not
         /// all providers have the concept of a schema, so this property is optional

--- a/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Sql/CachedSqlPerGuidSessionManagerSqlClientTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Sql/CachedSqlPerGuidSessionManagerSqlClientTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using LazyCache;
 using Lussatite.FeatureManagement.Net48.Tests.Testing.SQLServer;
 using Lussatite.FeatureManagement.SessionManagers;
 using TestCommon.Standard;
@@ -32,6 +33,7 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         }
 
         private readonly IDictionary<Guid, SqlSessionManager> _userSessionManagers;
+        private readonly IAppCache _appCache = new CachingService();
 
         private IDictionary<Guid,SqlSessionManager> CreateSuts()
         {
@@ -41,7 +43,7 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
             {
                 var setting = baseSetting.JsonClone();
                 setting.UserGuid = userGuid;
-                suts[userGuid] = new CachedSqlSessionManager(setting);
+                suts[userGuid] = new CachedSqlSessionManager(setting, appCache: _appCache);
             }
 
             return suts;

--- a/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Sql/CachedSqlSessionManagerSQLiteTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Sql/CachedSqlSessionManagerSQLiteTests.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using LazyCache;
 using Lussatite.FeatureManagement.Net48.Tests.Testing.SQLite;
 using Lussatite.FeatureManagement.SessionManagers;
 using TestCommon.Standard;
@@ -11,6 +12,7 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
     public class CachedSqlSessionManagerSQLiteTests
     {
         private readonly SQLiteDatabaseFixture _dbFixture;
+        private readonly IAppCache _appCache = new CachingService();
 
         public CachedSqlSessionManagerSQLiteTests(SQLiteDatabaseFixture dbFixture)
         {
@@ -22,7 +24,8 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
             var settings = _dbFixture.SqlSessionManagerSettings;
 
             return new CachedSqlSessionManager(
-                settings: settings
+                settings: settings,
+                appCache: _appCache
                 );
         }
 

--- a/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Sql/CachedSqlSessionManagerSqlClientTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Sql/CachedSqlSessionManagerSqlClientTests.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using LazyCache;
 using Lussatite.FeatureManagement.Net48.Tests.Testing.SQLServer;
 using Lussatite.FeatureManagement.SessionManagers;
 using TestCommon.Standard;
@@ -11,6 +12,7 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
     public class CachedSqlSessionManagerSqlClient
     {
         private readonly SqlServerDatabaseFixture _dbFixture;
+        private readonly IAppCache _appCache = new CachingService();
 
         public CachedSqlSessionManagerSqlClient(SqlServerDatabaseFixture dbFixture)
         {
@@ -22,7 +24,8 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
             var settings = _dbFixture.SqlSessionManagerSettings;
 
             return new CachedSqlSessionManager(
-                settings: settings
+                settings: settings,
+                appCache: _appCache
                 );
         }
 

--- a/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Sql/CachedSqlPerGuidSessionManagerSqlClientTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Sql/CachedSqlPerGuidSessionManagerSqlClientTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using LazyCache;
 using Lussatite.FeatureManagement.Net6.Tests.Testing.SQLServer;
 using Lussatite.FeatureManagement.SessionManagers;
 using TestCommon.Standard;
@@ -32,6 +33,7 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
         }
 
         private readonly IDictionary<Guid, SqlSessionManager> _userSessionManagers;
+        private readonly IAppCache _appCache = new CachingService();
 
         private IDictionary<Guid,SqlSessionManager> CreateSuts()
         {
@@ -41,7 +43,7 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
             {
                 var setting = baseSetting.JsonClone();
                 setting.UserGuid = userGuid;
-                suts[userGuid] = new CachedSqlSessionManager(setting);
+                suts[userGuid] = new CachedSqlSessionManager(setting, appCache: _appCache);
             }
 
             return suts;

--- a/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Sql/CachedSqlSessionManagerSQLiteTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Sql/CachedSqlSessionManagerSQLiteTests.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using LazyCache;
 using Lussatite.FeatureManagement.Net6.Tests.Testing.SQLite;
 using Lussatite.FeatureManagement.SessionManagers;
 using TestCommon.Standard;
@@ -11,6 +12,7 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
     public class CachedSqlSessionManagerSQLiteTests
     {
         private readonly SQLiteDatabaseFixture _dbFixture;
+        private readonly IAppCache _appCache = new CachingService();
 
         public CachedSqlSessionManagerSQLiteTests(SQLiteDatabaseFixture dbFixture)
         {
@@ -22,7 +24,8 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
             var settings = _dbFixture.SqlSessionManagerSettings;
 
             return new CachedSqlSessionManager(
-                settings: settings
+                settings: settings,
+                appCache: _appCache
                 );
         }
 

--- a/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Sql/CachedSqlSessionManagerSqlClientTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Sql/CachedSqlSessionManagerSqlClientTests.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using LazyCache;
 using Lussatite.FeatureManagement.Net6.Tests.Testing.SQLServer;
 using Lussatite.FeatureManagement.SessionManagers;
 using TestCommon.Standard;
@@ -11,6 +12,7 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
     public class CachedSqlSessionManagerSqlClient
     {
         private readonly SqlServerDatabaseFixture _dbFixture;
+        private readonly IAppCache _appCache = new CachingService();
 
         public CachedSqlSessionManagerSqlClient(SqlServerDatabaseFixture dbFixture)
         {
@@ -22,7 +24,8 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
             var settings = _dbFixture.SqlSessionManagerSettings;
 
             return new CachedSqlSessionManager(
-                settings: settings
+                settings: settings,
+                appCache: _appCache
                 );
         }
 

--- a/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/Sql/CachedSqlPerGuidSessionManagerSqlClientTests.cs
+++ b/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/Sql/CachedSqlPerGuidSessionManagerSqlClientTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using LazyCache;
 using Lussatite.FeatureManagement.NetCore31.Tests.Testing.SQLServer;
 using Lussatite.FeatureManagement.SessionManagers;
 using TestCommon.Standard;
@@ -32,6 +33,7 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
         }
 
         private readonly IDictionary<Guid, SqlSessionManager> _userSessionManagers;
+        private readonly IAppCache _appCache = new CachingService();
 
         private IDictionary<Guid,SqlSessionManager> CreateSuts()
         {
@@ -41,7 +43,7 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
             {
                 var setting = baseSetting.JsonClone();
                 setting.UserGuid = userGuid;
-                suts[userGuid] = new CachedSqlSessionManager(setting);
+                suts[userGuid] = new CachedSqlSessionManager(setting, appCache: _appCache);
             }
 
             return suts;

--- a/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/Sql/CachedSqlSessionManagerSQLiteTests.cs
+++ b/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/Sql/CachedSqlSessionManagerSQLiteTests.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using LazyCache;
 using Lussatite.FeatureManagement.NetCore31.Tests.Testing.SQLite;
 using Lussatite.FeatureManagement.SessionManagers;
 using TestCommon.Standard;
@@ -11,6 +12,7 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
     public class CachedSqlSessionManagerSQLiteTests
     {
         private readonly SQLiteDatabaseFixture _dbFixture;
+        private readonly IAppCache _appCache = new CachingService();
 
         public CachedSqlSessionManagerSQLiteTests(SQLiteDatabaseFixture dbFixture)
         {
@@ -22,7 +24,8 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
             var settings = _dbFixture.SqlSessionManagerSettings;
 
             return new CachedSqlSessionManager(
-                settings: settings
+                settings: settings,
+                appCache: _appCache
                 );
         }
 

--- a/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/Sql/CachedSqlSessionManagerSqlClientTests.cs
+++ b/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/Sql/CachedSqlSessionManagerSqlClientTests.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using LazyCache;
 using Lussatite.FeatureManagement.NetCore31.Tests.Testing.SQLServer;
 using Lussatite.FeatureManagement.SessionManagers;
 using TestCommon.Standard;
@@ -11,6 +12,7 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
     public class CachedSqlSessionManagerSqlClient
     {
         private readonly SqlServerDatabaseFixture _dbFixture;
+        private readonly IAppCache _appCache = new CachingService();
 
         public CachedSqlSessionManagerSqlClient(SqlServerDatabaseFixture dbFixture)
         {
@@ -22,7 +24,8 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
             var settings = _dbFixture.SqlSessionManagerSettings;
 
             return new CachedSqlSessionManager(
-                settings: settings
+                settings: settings,
+                appCache: _appCache
                 );
         }
 


### PR DESCRIPTION
Rework the calculation for the cache-keys so that CachedSqlSessionManager 
can use the global LazyCache IAppCache instance.  This reduces the number of
objects created and helps with caching of GUID-specific feature values across
multiple API calls.

The provided IAppCache can be a singleton after this change.

Because of implementation details, this has to be stored on the 
SqlSessionManagerSettings object instead of CachedSqlSessionManagerSettings.