### PR TITLE
Boost test iterations for per-GUID tests

### DIFF
--- a/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Sql/CachedSqlPerGuidSessionManagerSqlClientTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Sql/CachedSqlPerGuidSessionManagerSqlClientTests.cs
@@ -125,7 +125,7 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         public async Task Exercise_SetNullableValue()
         {
             const string baseName = Pfx+"_C997_ExerciseRepeatedly";
-            const int maxIterations = 1500;
+            const int maxIterations = 3500;
             for (var i = 0; i < maxIterations; i++)
             {
                 var userGuid = GetRandomUserGuid();
@@ -143,7 +143,7 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         public async Task Exercise_SetValue()
         {
             const string baseName = Pfx+"_C877_ExerciseRepeatedly";
-            const int maxIterations = 1500;
+            const int maxIterations = 3500;
             for (var i = 0; i < maxIterations; i++)
             {
                 var userGuid = GetRandomUserGuid();

--- a/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Sql/SqlPerGuidSessionManagerSqlClientTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net48.Tests/SessionManagers/Sql/SqlPerGuidSessionManagerSqlClientTests.cs
@@ -123,7 +123,7 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         public async Task Exercise_SetNullableValue()
         {
             const string baseName = Pfx+"_B473_ExerciseRepeatedly";
-            const int maxIterations = 500;
+            const int maxIterations = 1000;
             for (var i = 0; i < maxIterations; i++)
             {
                 var userGuid = GetRandomUserGuid();
@@ -141,7 +141,7 @@ namespace Lussatite.FeatureManagement.Net48.Tests.SessionManagers.Sql
         public async Task Exercise_SetValue()
         {
             const string baseName = Pfx+"_C985_ExerciseRepeatedly";
-            const int maxIterations = 500;
+            const int maxIterations = 1000;
             for (var i = 0; i < maxIterations; i++)
             {
                 var userGuid = GetRandomUserGuid();

--- a/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Sql/CachedSqlPerGuidSessionManagerSqlClientTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Sql/CachedSqlPerGuidSessionManagerSqlClientTests.cs
@@ -125,7 +125,7 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
         public async Task Exercise_SetNullableValue()
         {
             const string baseName = Pfx+"_C997_ExerciseRepeatedly";
-            const int maxIterations = 1500;
+            const int maxIterations = 3500;
             for (var i = 0; i < maxIterations; i++)
             {
                 var userGuid = GetRandomUserGuid();
@@ -143,7 +143,7 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
         public async Task Exercise_SetValue()
         {
             const string baseName = Pfx+"_C877_ExerciseRepeatedly";
-            const int maxIterations = 1500;
+            const int maxIterations = 3500;
             for (var i = 0; i < maxIterations; i++)
             {
                 var userGuid = GetRandomUserGuid();

--- a/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Sql/SqlPerGuidSessionManagerSqlClientTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net6.Tests/SessionManagers/Sql/SqlPerGuidSessionManagerSqlClientTests.cs
@@ -123,7 +123,7 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
         public async Task Exercise_SetNullableValue()
         {
             const string baseName = Pfx+"_B473_ExerciseRepeatedly";
-            const int maxIterations = 500;
+            const int maxIterations = 1000;
             for (var i = 0; i < maxIterations; i++)
             {
                 var userGuid = GetRandomUserGuid();
@@ -141,7 +141,7 @@ namespace Lussatite.FeatureManagement.Net6.Tests.SessionManagers.Sql
         public async Task Exercise_SetValue()
         {
             const string baseName = Pfx+"_C985_ExerciseRepeatedly";
-            const int maxIterations = 500;
+            const int maxIterations = 1000;
             for (var i = 0; i < maxIterations; i++)
             {
                 var userGuid = GetRandomUserGuid();

--- a/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/Sql/CachedSqlPerGuidSessionManagerSqlClientTests.cs
+++ b/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/Sql/CachedSqlPerGuidSessionManagerSqlClientTests.cs
@@ -125,7 +125,7 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
         public async Task Exercise_SetNullableValue()
         {
             const string baseName = Pfx+"_C997_ExerciseRepeatedly";
-            const int maxIterations = 1500;
+            const int maxIterations = 3500;
             for (var i = 0; i < maxIterations; i++)
             {
                 var userGuid = GetRandomUserGuid();
@@ -143,7 +143,7 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
         public async Task Exercise_SetValue()
         {
             const string baseName = Pfx+"_C877_ExerciseRepeatedly";
-            const int maxIterations = 1500;
+            const int maxIterations = 3500;
             for (var i = 0; i < maxIterations; i++)
             {
                 var userGuid = GetRandomUserGuid();

--- a/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/Sql/SqlPerGuidSessionManagerSqlClientTests.cs
+++ b/tests/Lussatite.FeatureManagement.NetCore31.Tests/SessionManagers/Sql/SqlPerGuidSessionManagerSqlClientTests.cs
@@ -123,7 +123,7 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
         public async Task Exercise_SetNullableValue()
         {
             const string baseName = Pfx+"_B473_ExerciseRepeatedly";
-            const int maxIterations = 500;
+            const int maxIterations = 1000;
             for (var i = 0; i < maxIterations; i++)
             {
                 var userGuid = GetRandomUserGuid();
@@ -141,7 +141,7 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests.SessionManagers.Sql
         public async Task Exercise_SetValue()
         {
             const string baseName = Pfx+"_C985_ExerciseRepeatedly";
-            const int maxIterations = 500;
+            const int maxIterations = 1000;
             for (var i = 0; i < maxIterations; i++)
             {
                 var userGuid = GetRandomUserGuid();


### PR DESCRIPTION
Because there are now 20 "users" in these tests, the iteration count should
be increased (versus the baseline tests).