### PR TITLE
Add Name property and WhyIsEnabledAsync()

### DIFF
--- a/src/Lussatite.FeatureManagement.SessionManagers/ClaimsPrincipal/ClaimsPrincipalSessionManager.cs
+++ b/src/Lussatite.FeatureManagement.SessionManagers/ClaimsPrincipal/ClaimsPrincipalSessionManager.cs
@@ -14,8 +14,15 @@ namespace Lussatite.FeatureManagement.SessionManagers
     /// <para>This type should be registered/constructed on a per-request basis
     /// since it takes dependency on the current user (<see cref="ClaimsPrincipal"/>).</para>
     /// </summary>
-    public class ClaimsPrincipalSessionManager : ISessionManager
+    public class ClaimsPrincipalSessionManager : ISessionManager, IHasNameProperty
     {
+        private string _name;
+        public string Name
+        {
+            get => string.IsNullOrEmpty(_name) ? GetType().Name : _name;
+            set => _name = value;
+        }
+
         /// <summary>The claim type that will be examined when determining whether the
         /// current <see cref="ClaimsPrincipal"/> has the claim for a particular
         /// feature name. The expectation is that the value of this claim will

--- a/src/Lussatite.FeatureManagement.SessionManagers/Sql/SqlSessionManager.cs
+++ b/src/Lussatite.FeatureManagement.SessionManagers/Sql/SqlSessionManager.cs
@@ -10,8 +10,15 @@ namespace Lussatite.FeatureManagement.SessionManagers
     /// <summary>
     /// <para>A read-only or read-write implementation of <see cref="ISessionManager"/>.</para>
     /// </summary>
-    public class SqlSessionManager : ILussatiteSessionManager
+    public class SqlSessionManager : ILussatiteSessionManager, IHasNameProperty
     {
+        private string _name;
+        public string Name
+        {
+            get => string.IsNullOrEmpty(_name) ? GetType().Name : _name;
+            set => _name = value;
+        }
+
         public SqlSessionManagerSettings Settings { get; }
 
         public SqlSessionManager(

--- a/src/Lussatite.FeatureManagement.SessionManagers/Static/StaticAnswerSessionManager.cs
+++ b/src/Lussatite.FeatureManagement.SessionManagers/Static/StaticAnswerSessionManager.cs
@@ -9,7 +9,7 @@ namespace Lussatite.FeatureManagement.SessionManagers
     /// which returns a static pre-defined (during the constructor) answer for the feature.
     /// This is mostly useful when doing unit/integration testing and not as a production use case.
     /// </summary>
-    public class StaticAnswerSessionManager : ISessionManager
+    public class StaticAnswerSessionManager : ISessionManager, IHasNameProperty
     {
         private readonly IDictionary<string, bool?> _features;
 
@@ -18,6 +18,13 @@ namespace Lussatite.FeatureManagement.SessionManagers
             )
         {
             _features = features;
+        }
+
+        private string _name;
+        public string Name
+        {
+            get => string.IsNullOrEmpty(_name) ? GetType().Name : _name;
+            set => _name = value;
         }
 
         /// <summary>This is a read-only <see cref="ISessionManager"/> so this method does nothing. </summary>

--- a/src/Lussatite.FeatureManagement/IHasNameProperty.cs
+++ b/src/Lussatite.FeatureManagement/IHasNameProperty.cs
@@ -1,0 +1,7 @@
+namespace Lussatite.FeatureManagement
+{
+    public interface IHasNameProperty
+    {
+        string Name { get; }
+    }
+}

--- a/src/Lussatite.FeatureManagement/WhyEnabledResponse.cs
+++ b/src/Lussatite.FeatureManagement/WhyEnabledResponse.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using Microsoft.FeatureManagement;
+
+namespace Lussatite.FeatureManagement
+{
+    /// <summary>Explain why a particular feature name comes back as enabled/disabled including
+    /// which <see cref="ISessionManager"/> was responsible.  This response is designed
+    /// to help advanced users diagnose issues.</summary>
+    public class WhyEnabledResponse
+    {
+        public string FeatureName { get; set; }
+
+        public bool Enabled { get; set; }
+
+        /// <summary>The "name" of the ISessionManager which returned the first definitive
+        /// response for the feature.</summary>
+        public string SessionManagerName { get; set; }
+
+        /// <summary>Details about the various session managers and what values they returned.</summary>
+        public ICollection<WhyEnabledSessionManagerResponse> SessionManagers { get; }
+            = new List<WhyEnabledSessionManagerResponse>();
+    }
+
+    public class WhyEnabledSessionManagerResponse
+    {
+        /// <summary>Name of the <see cref="ISessionManager"/> if it implements <see cref="IHasNameProperty"/>.
+        /// Otherwise it will return the Type name.</summary>
+        public string Name { get; set; }
+
+        /// <summary>Feature value in this <see cref="ISessionManager"/>.</summary>
+        public bool? Enabled { get; set; }
+    }
+}

--- a/tests/Lussatite.FeatureManagement.Net48.Tests/FeatureManagers/LussatiteFeatureManagerTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net48.Tests/FeatureManagers/LussatiteFeatureManagerTests.cs
@@ -50,8 +50,13 @@ namespace Lussatite.FeatureManagement.Net48.Tests.FeatureManagers
                 sessionManagers: new[] { provider },
                 featureNames: TestFeatures.All.Value
                 );
+
             var result = await sut.IsEnabledAsync(featureName);
             Assert.Equal(expected, result);
+
+            var explanationResult = await sut.WhyIsEnabledAsync(featureName);
+            Assert.Equal(featureName, explanationResult.FeatureName);
+            Assert.Equal(expected, explanationResult.Enabled);
         }
     }
 }

--- a/tests/Lussatite.FeatureManagement.Net48.Tests/FeatureManagers/LussatiteLazyCacheFeatureManagerTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net48.Tests/FeatureManagers/LussatiteLazyCacheFeatureManagerTests.cs
@@ -29,7 +29,6 @@ namespace Lussatite.FeatureManagement.Net48.Tests.FeatureManagers
             Assert.NotNull(sut);
         }
 
-
         [Theory]
         [InlineData(false, TestFeatures.NotInAppConfig)]
         [InlineData(false, TestFeatures.NullInAppConfig)]
@@ -51,8 +50,13 @@ namespace Lussatite.FeatureManagement.Net48.Tests.FeatureManagers
                 sessionManagers: new[] { provider },
                 featureNames: TestFeatures.All.Value
                 );
+
             var result = await sut.IsEnabledAsync(featureName);
             Assert.Equal(expected, result);
+
+            var explanationResult = await sut.WhyIsEnabledAsync(featureName);
+            Assert.Equal(featureName, explanationResult.FeatureName);
+            Assert.Equal(expected, explanationResult.Enabled);
         }
     }
 }

--- a/tests/Lussatite.FeatureManagement.Net6.Tests/FeatureManagers/LussatiteFeatureManagerTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net6.Tests/FeatureManagers/LussatiteFeatureManagerTests.cs
@@ -61,8 +61,13 @@ namespace Lussatite.FeatureManagement.Net6.Tests.FeatureManagers
                 sessionManagers: new[] { provider },
                 featureNames: TestFeatures.All.Value
                 );
+
             var result = await sut.IsEnabledAsync(featureName);
             Assert.Equal(expected, result);
+
+            var explanationResult = await sut.WhyIsEnabledAsync(featureName);
+            Assert.Equal(featureName, explanationResult.FeatureName);
+            Assert.Equal(expected, explanationResult.Enabled);
         }
     }
 }

--- a/tests/Lussatite.FeatureManagement.Net6.Tests/FeatureManagers/LussatiteLazyCacheFeatureManagerTests.cs
+++ b/tests/Lussatite.FeatureManagement.Net6.Tests/FeatureManagers/LussatiteLazyCacheFeatureManagerTests.cs
@@ -40,7 +40,6 @@ namespace Lussatite.FeatureManagement.Net6.Tests.FeatureManagers
             Assert.NotNull(sut);
         }
 
-
         [Theory]
         [InlineData(false, TestFeatures.NotInAppConfig)]
         [InlineData(false, TestFeatures.NullInAppConfig)]
@@ -62,8 +61,13 @@ namespace Lussatite.FeatureManagement.Net6.Tests.FeatureManagers
                 sessionManagers: new[] { provider },
                 featureNames: TestFeatures.All.Value
                 );
+
             var result = await sut.IsEnabledAsync(featureName);
             Assert.Equal(expected, result);
+
+            var explanationResult = await sut.WhyIsEnabledAsync(featureName);
+            Assert.Equal(featureName, explanationResult.FeatureName);
+            Assert.Equal(expected, explanationResult.Enabled);
         }
     }
 }

--- a/tests/Lussatite.FeatureManagement.NetCore31.Tests/FeatureManagers/LussatiteFeatureManagerTests.cs
+++ b/tests/Lussatite.FeatureManagement.NetCore31.Tests/FeatureManagers/LussatiteFeatureManagerTests.cs
@@ -4,7 +4,7 @@ using Lussatite.FeatureManagement.SessionManagers;
 using Microsoft.Extensions.Configuration;
 using Xunit;
 
-namespace Lussatite.FeatureManagement.NetCore31.Tests
+namespace Lussatite.FeatureManagement.NetCore31.Tests.FeatureManagers
 {
     public class LussatiteFeatureManagerTests
     {
@@ -61,8 +61,13 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests
                 sessionManagers: new[] { provider },
                 featureNames: TestFeatures.All.Value
                 );
+
             var result = await sut.IsEnabledAsync(featureName);
             Assert.Equal(expected, result);
+
+            var explanationResult = await sut.WhyIsEnabledAsync(featureName);
+            Assert.Equal(featureName, explanationResult.FeatureName);
+            Assert.Equal(expected, explanationResult.Enabled);
         }
     }
 }

--- a/tests/Lussatite.FeatureManagement.NetCore31.Tests/FeatureManagers/LussatiteLazyCacheFeatureManagerTests.cs
+++ b/tests/Lussatite.FeatureManagement.NetCore31.Tests/FeatureManagers/LussatiteLazyCacheFeatureManagerTests.cs
@@ -4,7 +4,7 @@ using Lussatite.FeatureManagement.SessionManagers;
 using Microsoft.Extensions.Configuration;
 using Xunit;
 
-namespace Lussatite.FeatureManagement.NetCore31.Tests
+namespace Lussatite.FeatureManagement.NetCore31.Tests.FeatureManagers
 {
     public class LussatiteLazyCacheFeatureManagerTests
     {
@@ -40,7 +40,6 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests
             Assert.NotNull(sut);
         }
 
-
         [Theory]
         [InlineData(false, TestFeatures.NotInAppConfig)]
         [InlineData(false, TestFeatures.NullInAppConfig)]
@@ -62,8 +61,13 @@ namespace Lussatite.FeatureManagement.NetCore31.Tests
                 sessionManagers: new[] { provider },
                 featureNames: TestFeatures.All.Value
                 );
+
             var result = await sut.IsEnabledAsync(featureName);
             Assert.Equal(expected, result);
+
+            var explanationResult = await sut.WhyIsEnabledAsync(featureName);
+            Assert.Equal(featureName, explanationResult.FeatureName);
+            Assert.Equal(expected, explanationResult.Enabled);
         }
     }
 }


### PR DESCRIPTION
WhyIsEnabledAsync() returns a response object that helps provide insight into why the feature value came back as true/false.  As part of this, individual session managers can have descriptive names applied.